### PR TITLE
Finalize API for basic statistics functions

### DIFF
--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -74,6 +74,7 @@ module DataArrays
     include("extras.jl")
     include("grouping.jl")
     include("statistics.jl")
+    include("stats.jl")
     include("predicates.jl")
     include("literals.jl")
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -145,18 +145,8 @@ const bit_operators = [:(Base.(:&)),
                        :(Base.(:|)),
                        :(Base.(:$))]
 
-const unary_vector_operators = [:(Base.minimum),
-                                :(Base.maximum),
-                                :(Base.prod),
-                                :(Base.sum),
-                                :(Base.mean),
-                                :(Base.median),
-                                :(Base.std),
-                                :(Base.var),
-                                :(Stats.mad),
-                                :(Base.norm),
-                                :(Stats.skewness),
-                                :(Stats.kurtosis)]
+const unary_vector_operators = [:(Stats.mad),
+                                :(Base.norm)]
 
 # TODO: dist, iqr
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,0 +1,170 @@
+function Base.mean{T <: Real}(da::DataArray{T};
+                              skipna::Bool = false)
+    s, n = 0.0, 0
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            s += da.data[i]
+            n += 1
+        end
+    end
+    return s / n
+end
+
+function Base.median{T <: Real}(da::DataArray{T};
+                                skipna::Bool = false)
+    if !skipna
+        return median(array(da))
+    else
+        return median(removeNA(da))
+    end
+end
+
+function Base.var{T <: Real}(da::DataArray{T};
+                             skipna::Bool = false)
+    s, n = 0.0, 0
+    m = mean(da, skipna = skipna)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            z = (da.data[i] - m)
+            s += z * z
+            n += 1
+        end
+    end
+    return s / (n - 1)
+end
+
+function Base.std{T <: Real}(da::DataArray{T};
+                             skipna::Bool = false)
+    s, n = 0.0, 0
+    m = mean(da, skipna = skipna)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            z = (da.data[i] - m)
+            s += z * z
+            n += 1
+        end
+    end
+    return sqrt(s / (n - 1))
+end
+
+function Base.minimum{T <: Real}(da::DataArray{T};
+                                 skipna::Bool = false)
+    m = typemax(T)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            m = min(m, da.data[i])
+        end
+    end
+    return m
+end
+
+function Base.maximum{T <: Real}(da::DataArray{T};
+                                 skipna::Bool = false)
+    m = typemin(T)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            m = max(m, da.data[i])
+        end
+    end
+    return m
+end
+
+function Base.prod{T <: Real}(da::DataArray{T};
+                              skipna::Bool = false)
+    r = one(T)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            r *= da.data[i]
+        end
+    end
+    return r
+end
+
+function Base.sum{T <: Real}(da::DataArray{T};
+                             skipna::Bool = false)
+    r = zero(T)
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            r += da.data[i]
+        end
+    end
+    return r
+end
+
+function Stats.skewness{T <: Real}(da::DataArray{T};
+                                   skipna::Bool = false,
+                                   m::Real = mean(da, skipna = skipna))
+    n = 0
+    cm2 = 0.0   # empirical 2nd centered moment (variance)
+    cm3 = 0.0   # empirical 3rd centered moment
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            x_i = da.data[i]
+            z = x_i - m
+            z2 = z * z
+            cm2 += z2
+            cm3 += z2 * z
+            n += 1
+        end
+    end
+    cm3 /= n
+    cm2 /= n
+    return cm3 / (cm2^1.5)
+end
+
+function Stats.kurtosis{T <: Real}(da::DataArray{T};
+                                   skipna::Bool = false,
+                                   m::Real = mean(da, skipna = skipna))
+    n = 0
+    cm2 = 0.0  # empirical 2nd centered moment (variance)
+    cm4 = 0.0  # empirical 4th centered moment
+    for i in 1:length(da)
+        if da.na[i]
+            if !skipna
+                throw(NAException())
+            end
+        else
+            x_i = da.data[i]
+            z = x_i - m
+            z2 = z * z
+            cm2 += z2
+            cm4 += z2 * z2
+            n += 1
+        end
+    end
+    cm4 /= n
+    cm2 /= n
+    return (cm4 / (cm2^2)) - 3.0
+end


### PR DESCRIPTION
This branch restarts the process of adding missing functionality to our basic statistics functions for skipping `NA` values while calculating statistics. The code is quite repetitive and can be DRY'ed out in a future run.

For now what I'd like to do is agree on what functionality these functions should offer. For now, I've taken every function I'm replacing and added a `skipna` keyword that allows one to skip over `NA` values. For `skewness` and `kurtosis`, this keyword has to be passed to the function that computes centers when they are not pre-specified, so the center is now also a keyword called `m`. (FWIW, I'm not a big fan of specifying centers that aren't the mean, so we might take that out. I'd argue it also doesn't belong in Base: neither R nor SciPy offer that functionality. I'm not sure why we do.)

Things we're not doing that R does:
- For `mean`, `std` and `var`, R also offers the ability to trim out extreme data points.
- For `median`, R also offers the ability to use the `lo` or `hi` median, which is simply the lower or higher value in an array with an even number of elements, instead of their average.

Unlike R, Julia Base expects that we will offer:
- Slices to compute column-wise, row-wise and other dimension-wise functions.
- Use of non-standard centers
