### PR TITLE
Rename removeNA and fix its implementation

### DIFF
--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -23,10 +23,10 @@ module DataArrays
            DataMatrix,
            DataVector,
            each_failNA,
-           each_removeNA,
+           each_dropna,
            each_replaceNA,
            EachFailNA,
-           EachRemoveNA,
+           EachDropNA,
            EachReplaceNA,
            failNA,
            FastPerm,
@@ -52,13 +52,13 @@ module DataArrays
            PooledDataVecs,
            PooledDataVector,
            reldiff,
-           removeNA,
+           dropna,
            reorder,
            rep,
            replace!,
            replaceNA,
-           set_levels!,
-           set_levels,
+           setlevels!,
+           setlevels,
            tail,
            xtab,
            xtabs
@@ -76,4 +76,8 @@ module DataArrays
     include("statistics.jl")
     include("predicates.jl")
     include("literals.jl")
+
+    Base.@deprecate removeNA dropna
+    Base.@deprecate set_levels setlevels
+    Base.@deprecate set_levels! setlevels!
 end

--- a/src/datamatrix.jl
+++ b/src/datamatrix.jl
@@ -18,7 +18,7 @@ end
 function Base.getindex(x::DataMatrix,
                        i::SingleIndex,
                        col_inds::AbstractDataVector)
-    getindex(x, i, removeNA(col_inds))
+    getindex(x, i, dropna(col_inds))
 end
 # TODO: Make inds::AbstractVector
 function Base.getindex(x::DataMatrix,
@@ -36,7 +36,7 @@ end
 function Base.getindex(x::DataMatrix,
                        row_inds::AbstractDataVector,
                        j::SingleIndex)
-    getindex(x, removeNA(row_inds), j)
+    getindex(x, dropna(row_inds), j)
 end
 # TODO: Make inds::AbstractVector
 function Base.getindex(x::DataMatrix,
@@ -58,7 +58,7 @@ function Base.getindex(x::DataMatrix,
                        col_inds::AbstractDataVector)
     return getindex(x,
                     find(row_inds),
-                    removeNA(col_inds))
+                    dropna(col_inds))
 end
 # TODO: Make inds::AbstractVector
 function Base.getindex(x::DataMatrix,
@@ -72,22 +72,22 @@ function Base.getindex(x::DataMatrix,
                        row_inds::AbstractDataVector,
                        col_inds::AbstractDataVector{Bool})
     return getindex(x,
-                    removeNA(row_inds),
+                    dropna(row_inds),
                     find(col_inds))
 end
 function Base.getindex(x::DataMatrix,
                        row_inds::AbstractDataVector,
                        col_inds::AbstractDataVector)
     return getindex(x,
-                    removeNA(row_inds),
-                    removeNA(col_inds))
+                    dropna(row_inds),
+                    dropna(col_inds))
 end
 
 # TODO: Make inds::AbstractVector
 function Base.getindex(x::DataMatrix,
                        row_inds::AbstractDataVector,
                        col_inds::MultiIndex)
-    return getindex(x, removeNA(row_inds), col_inds)
+    return getindex(x, dropna(row_inds), col_inds)
 end
 
 # TODO: Make inds::AbstractVector
@@ -103,7 +103,7 @@ end
 function Base.getindex(x::DataMatrix,
                        row_inds::MultiIndex,
                        col_inds::AbstractDataVector)
-    return getindex(x, row_inds, removeNA(col_inds))
+    return getindex(x, row_inds, dropna(col_inds))
 end
 
 # TODO: Make inds::AbstractVector

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -175,7 +175,7 @@ const ffts = [:(Base.fft)]
 const binary_vector_operators = [:(Base.dot),
                                  :(Base.cor),
                                  :(Base.cov),
-                                 :(Stats.cor_spearman)]
+                                 :(Stats.corspearman)]
 
 const rowwise_operators = [:rowminimums,
                            :rowmaxs,

--- a/test/data.jl
+++ b/test/data.jl
@@ -91,7 +91,7 @@ module TestData
     # @assert isequal(pdvstr .== "two", PooledDataVector[false, false, true, true, NA, false, false])
 
     #test_group("DataVector to something else")
-    @assert all(removeNA(dvint) .== [1, 2, 4])
+    @assert all(dropna(dvint) .== [1, 2, 4])
     @assert all(array(dvint, 0) .== [1, 2, 0, 4])
     utf8three = convert(UTF8String, "three")
     asciithree = convert(ASCIIString, "three")
@@ -103,19 +103,19 @@ module TestData
     @assert repr(dvint) == "[1,2,NA,4]"
 
     #test_group("PooledDataVector to something else")
-    @assert all(removeNA(pdvstr) .== ["one", "one", "two", "two", "one", "one"])
+    @assert all(dropna(pdvstr) .== ["one", "one", "two", "two", "one", "one"])
     @assert all(array(pdvstr, "nine") .== ["one", "one", "two", "two", "nine", "one", "one"])
     @assert all([length(i)::Int for i in pdvstr] .== [3, 3, 3, 3, 1, 3, 3])
     @assert string(pdvstr[1:3]) == "[one, one, two]"
 
     #test_group("DataVector Filter and Replace")
-    @assert isequal(removeNA(dvint), [1, 2, 4])
+    @assert isequal(dropna(dvint), [1, 2, 4])
     @assert isequal(array(dvint, 7), [1, 2, 7, 4])
-    @assert sum(removeNA(dvint)) == 7
+    @assert sum(dropna(dvint)) == 7
     @assert sum(array(dvint, 7)) == 14
 
     #test_group("PooledDataVector Filter and Replace")
-    @assert reduce(string, "", removeNA(pdvstr)) == "oneonetwotwooneone"
+    @assert reduce(string, "", dropna(pdvstr)) == "oneonetwotwooneone"
     @assert reduce(string, "", array(pdvstr, "!")) == "oneonetwotwo!oneone"
 
     #test_group("DataVector assignment")

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -7,12 +7,12 @@ module TestNAs
 	dv = DataArray([1, 2, 3], [false, false, false])
 
 	failNA(dv)
-	removeNA(dv)
+	dropna(dv)
 	replaceNA(dv, 3)
 	for v in each_failNA(dv)
 		println(v)
 	end
-	for v in each_removeNA(dv)
+	for v in each_dropna(dv)
 		println(v)
 	end
 	for v in each_replaceNA(dv, 3)
@@ -22,12 +22,12 @@ module TestNAs
 	dv[1] = NA
 
 	failNA(dv)
-	removeNA(dv)
+	dropna(dv)
 	replaceNA(dv, 3)
 	for v in each_failNA(dv)
 		println(v)
 	end
-	for v in each_removeNA(dv)
+	for v in each_dropna(dv)
 		println(v)
 	end
 	for v in each_replaceNA(dv, 3)

--- a/test/newtests/dataarray.jl
+++ b/test/newtests/dataarray.jl
@@ -122,11 +122,11 @@ module TestDataArrays
 	array(DataArray([1, 0, 3], [false, true, false]), -1)
 	array(DataArray([1, 2, 3], [false, false, false]), -1)
 
-	# removeNA(da::DataArray)
-	removeNA(DataArray([1, 0, 3], [false, true, false]))
-	removeNA(DataArray([1, 2, 3], [false, false, false]))
-	# removeNA{T}(da::AbstractDataVector{T})
-	# removeNA(@data([1, NA, 3]))
+	# dropna(da::DataArray)
+	dropna(DataArray([1, 0, 3], [false, true, false]))
+	dropna(DataArray([1, 2, 3], [false, false, false]))
+	# dropna{T}(da::AbstractDataVector{T})
+	# dropna(@data([1, NA, 3]))
 
 	# Iterators
 

--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -2,30 +2,30 @@ module TestPDA
 	using Base.Test
 	using DataArrays
 
-	p = PooledDataArray((@data [9, 9, 8, NA, 1, 1]))
+	p = @pdata [9, 9, 8, NA, 1, 1]
 	pcopy = copy(p)
-	@assert levels(p) == [1,8,9]
-	@assert levels(set_levels(p, ["a", "b", "c"])) == ["a", "b", "c"]
-	@assert removeNA(set_levels(p, (@data ["a", "b", NA]))) == ["b", "a", "a"]
-	@assert removeNA(set_levels(p, (@data ["a", "b", "a"]))) == ["a", "a", "b", "a", "a"]
-	@assert levels(set_levels(p, (@data ["a", "b", "a"]))) == ["a", "b"]
-	@assert levels(set_levels(p, [1 => 111])) == [111, 8, 9]
-	@assert levels(set_levels(p, [1 => 111, 8 => NA])) == [111, 9]
-	@assert levels(PooledDataArray(p, [9,8,1])) == [9,8,1]
-	@assert levels(PooledDataArray(p, [9,8])) == [9,8]
-	@assert removeNA(PooledDataArray(p, [9,8])) == [9,9,8]
+	@assert levels(p) == [1, 8, 9]
+	@assert levels(setlevels(p, ["a", "b", "c"])) == ["a", "b", "c"]
+	@assert dropna(setlevels(p, (@data ["a", "b", NA]))) == ["b", "a", "a"]
+	@assert dropna(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "a", "b", "a", "a"]
+	@assert levels(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "b"]
+	@assert levels(setlevels(p, [1 => 111])) == [111, 8, 9]
+	@assert levels(setlevels(p, [1 => 111, 8 => NA])) == [111, 9]
+	@assert levels(PooledDataArray(p, [9, 8, 1])) == [9, 8, 1]
+	@assert levels(PooledDataArray(p, [9, 8])) == [9, 8]
+	@assert dropna(PooledDataArray(p, [9, 8])) == [9, 9, 8]
 	@assert levels(PooledDataArray(p, levels(p)[[3,2,1]])) == [9,8,1]
 	v = [1:6]
-	#@assert isequal(p, reorder(p))
-	#@assert levels(reorder(p, v)) == [9,8,1]
+	@assert isequal(p, reorder(p))
+	# @assert levels(reorder(p, v)) == [9,8,1]
 	@assert isequal(p, pcopy)
 
-	@assert levels(set_levels!(copy(p), [10,80,90])) == [10, 80, 90]
-	@assert levels(set_levels!(copy(p), [1,8,1])) == [1, 8]
-	@assert levels(set_levels!(copy(p), (@data [1, 8, NA]))) == [1, 8]
-	@assert levels(set_levels!(copy(p), [1,8,9, 10])) == [1, 8, 9, 10]
-	@assert levels(set_levels!(copy(p), [1 => 111])) == [111, 8, 9]
-	@assert levels(set_levels!(copy(p), [1 => 111, 8 => NA])) == [111, 9]
+	@assert levels(setlevels!(copy(p), [10,80,90])) == [10, 80, 90]
+	@assert levels(setlevels!(copy(p), [1,8,1])) == [1, 8]
+	@assert levels(setlevels!(copy(p), (@data [1, 8, NA]))) == [1, 8]
+	@assert levels(setlevels!(copy(p), [1,8,9, 10])) == [1, 8, 9, 10]
+	@assert levels(setlevels!(copy(p), [1 => 111])) == [111, 8, 9]
+	@assert levels(setlevels!(copy(p), [1 => 111, 8 => NA])) == [111, 9]
 
 	pp = PooledDataArray(Any[])
 	@assert length(pp) == 0


### PR DESCRIPTION
I've come to really dislike the use of caps in the name for `removeNA`, which I think is also too long. It's renamed `dropna` in this PR.

I also dislike the absence of a custom implementation of `dropna` for PDA's, so I added one.

I decided to make `dropna` only apply to DV's and PDV's because the operation doesn't make sense for higher-order tensors.

Looking through these changes, I realize that the iterators look really ugly now. Will fix them before this is merged.
