### PR TITLE
Use Stats 0.3. Fixes #40.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.2-
-Stats
+Stats 0.3

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -241,7 +241,7 @@ end
 function PooledDataArray{S,R,N}(x::PooledDataArray{S,R,N},
                                 newpool::Vector{S})
     # QUESTION: should we have a ! version of this? If so, needs renaming?
-    tidx::Array{R} = findat(x.pool, newpool)
+    tidx::Array{R} = findat(newpool, x.pool)
     refs = zeros(R, length(x))
     for i in 1:length(refs)
         if x.refs[i] != 0 
@@ -257,7 +257,7 @@ myunique(x::AbstractDataVector) = myunique(removeNA(x))   # gets the ordering ri
 function set_levels{T,R}(x::PooledDataArray{T,R}, newpool::AbstractVector)
     pool = myunique(newpool)
     refs = zeros(R, length(x))
-    tidx::Array{R} = findat(newpool, pool)
+    tidx::Array{R} = findat(pool, newpool)
     tidx[isna(newpool)] = 0
     for i in 1:length(refs)
         if x.refs[i] != 0
@@ -273,7 +273,7 @@ function set_levels!{T,R}(x::PooledDataArray{T,R}, newpool::AbstractVector{T})
         return x
     else
         x.pool = myunique(newpool)
-        tidx::Array{R} = findat(newpool, x.pool)
+        tidx::Array{R} = findat(x.pool, newpool)
         tidx[isna(newpool)] = 0
         for i in 1:length(x.refs)
             if x.refs[i] != 0
@@ -684,8 +684,8 @@ function PooledDataVecs{S,Q<:Integer,R<:Integer,N}(v1::PooledDataArray{S,Q,N},
               sz <= typemax(Uint32) ? Uint32 :
                                       Uint64
 
-    tidx1 = convert(Vector{REFTYPE}, findat(v1.pool, pool))
-    tidx2 = convert(Vector{REFTYPE}, findat(v2.pool, pool))
+    tidx1 = convert(Vector{REFTYPE}, findat(pool, v1.pool))
+    tidx2 = convert(Vector{REFTYPE}, findat(pool, v2.pool))
     refs1 = zeros(REFTYPE, length(v1))
     refs2 = zeros(REFTYPE, length(v2))
     for i in 1:length(refs1)

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -1,6 +1,18 @@
 module TestExtras
 	using Base.Test
 	using DataArrays
+	using Stats
+	
+	##########
+	## countmap
+	##########
+
+	d = @data [NA,3,3]
+	w = weights([1.1,2.2,3.3])
+	cm = Dict{Union(Int, NAtype), Int}(@data([NA,3]), [1,2])
+	cmw = Dict{Union(Int, NAtype), Real}(@data([NA,3]), [1.1,5.5])
+	@assert isequal(countmap(d), cm)
+	@assert isequal(countmap(d, w), cmw)
 
 	##########
 	## cut


### PR DESCRIPTION
Couldn't figure out how to define `addcounts!` methods with the union specified (e.g `Stats.addcounts!{T}(cm::Dict{Union(T, NAtype), Int}, x::AbstractDataArray{T}`), so I'd be interested to see how to do that.
