### PR TITLE
Drop DataArray constructors that don't match Array constructors

### DIFF
--- a/src/abstractdataarray.jl
+++ b/src/abstractdataarray.jl
@@ -50,3 +50,262 @@ function Base.copy!(dest::AbstractDataArray, src::Any)
     end
     return dest
 end
+
+# Generic iteration over AbstractDataArray's
+
+# TODO: Document
+Base.start(x::AbstractDataArray) = 1
+
+# TODO: Document
+Base.next(x::AbstractDataArray, state::Integer) = (x[state], state + 1)
+
+# TODO: Document
+Base.done(x::AbstractDataArray, state::Integer) = state > length(x)
+
+#' @description
+#'
+#' Determine if any of the entries of an AbstractArray are `NA`.
+#'
+#' @param a::AbstractArray{T, N} The AbstractArray whose elements will
+#'        be assessed.
+#'
+#' @returns out::Bool Are any of the elements of `a` an `NA` value?
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' anyna(a)
+anyna(a::AbstractArray) = false # -> Bool
+
+#' @description
+#'
+#' Determine if any of the entries of an DataArray are `NA`.
+#'
+#' @param da::DataArray{T, N} The DataArray whose elements will
+#'        be assessed.
+#'
+#' @returns out::Bool Are any of the elements of `a` an `NA` value?
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' anyna(da)
+anyna(d::AbstractDataArray) = any(isna, d) # -> Bool
+
+#' @description
+#'
+#' Determine if all of the entries of an AbstractArray are `NA`.
+#'
+#' @param a::AbstractArray{T, N} The AbstractArray whose elements will
+#'        be assessed.
+#'
+#' @returns out::Bool Are all of the elements of `a` an `NA` value?
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' allna(a)
+allna(a::AbstractArray) = false # -> Bool
+
+#' @description
+#'
+#' Determine if all of the entries of an DataArray are `NA`.
+#'
+#' @param da::DataArray{T, N} The DataArray whose elements will
+#'        be assessed.
+#'
+#' @returns out::Bool Are all of the elements of `a` an `NA` value?
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' allna(da)
+allna(d::AbstractDataArray) = all(isna, d) # -> Bool
+
+#' @description
+#'
+#' Determine if the values of an AbstractArray are `NA`.
+#'
+#' @param a::AbstractArray{T, N} The AbstractArray whose missingness will
+#'        be assessed.
+#'
+#' @returns na::BitArray{N} Elementwise Boolean whether entry is missing.
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' isna(a)
+isna(a::AbstractArray) = falses(size(a)) # -> BitArray
+
+# TODO: Remove this method? It seems like a trap to me.
+#' @description
+#'
+#' Insert a set of values, `vals`, into the positions described
+#' by `inds`. The inserted values, `vals`, are echoed back as the return
+#' value.
+#'
+#' NB: The indices in `inds` must be exhaustive.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param vals::AbstractVector A set of values to be inserted into the
+#'        specified entries of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to
+#'        be modified.
+#'
+#' @returns vals::AbstractVector The values inserted into `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[false, true, true]] = [5.0, 5.0]
+function Base.setindex!(da::AbstractDataArray,
+                        vals::AbstractVector,
+                        inds::AbstractVector{Bool})
+	if size(inds) != size(da)
+		throw(ArgumentError("Boolean indices must be exhaustive"))
+	end
+    return setindex!(da, vals, find(inds))
+end
+
+#' @description
+#'
+#' Insert a set of values, `vals`, into the positions described
+#' by `inds`. The inserted values, `vals`, are echoed back as the return
+#' value.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param vals::AbstractVector A set of values to be inserted into the
+#'        specified entries of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to
+#'        be modified.
+#'
+#' @returns vals::AbstractVector The values inserted into `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[1, 3]] = [5.0, 5.]
+function Base.setindex!(da::AbstractDataArray,
+                        vals::AbstractVector,
+                        inds::AbstractVector)
+	if length(vals) != length(inds)
+		throw(ArgumentError("Values and indices must have the same length"))
+	end
+    for (val, ind) in zip(vals, inds)
+        da[ind] = val
+    end
+    return vals
+end
+
+#' @description
+#'
+#' Insert a value, `val`, of type `Any` into the positions described
+#' by `inds`. The inserted value, `val`, is echoed back as the return
+#' value.
+#'
+#' NB: The indices in `inds` must be exhaustive.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::Any A value to be inserted into the specified entries of `da`.
+#' @param inds::AbstractVector{Bool} A Boolean vector of indices of `da` to
+#'        be modified.
+#'
+#' @returns val::T The value inserted into `da`, converted to the element
+#'          type of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[false, true]] = 5.0
+function Base.setindex!{T}(da::AbstractDataArray{T},
+                           val::Any,
+                           inds::AbstractVector{Bool})
+    return setindex!(da, convert(T, val), find(inds))
+end
+
+#' @description
+#'
+#' Insert a value, `val`, of type `Any` into the positions described
+#' by `inds`. The inserted value, `val`, is echoed back as the return
+#' value. Note that `val` be coerced to the element type of `da`, which
+#' may fail.
+#'
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::Any A value to be inserted into the specified entries of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to be modified.
+#'
+#' @returns val::T The value inserted into `da`, converted to the element
+#'          type of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[1:3] = 5.0
+function Base.setindex!{T}(da::AbstractDataArray{T},
+                           val::Any,
+                           inds::AbstractVector)
+    val = convert(T, val)
+    for ind in inds
+        da[ind] = val
+    end
+    return val
+end
+
+# TODO: Include BitArray indexing here.
+#' @description
+#'
+#' Insert a value, `val`, of type `Any` into the positions described
+#' by `inds`. The inserted value, `val`, is echoed back as the return
+#' value.
+#'
+#' NB: The vector of indices, `inds`, must exhausitively state for every
+#' element of `da` whether it is being modified or not.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::Any A value to be inserted into the specified entries of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to be modified.
+#'
+#' @returns val::T The value inserted into `da`, converted to the element
+#'          type of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[true, false, false]] = 5.0
+function Base.setindex!(da::AbstractDataArray,
+                        val::Any,
+                        inds::AbstractVector{Bool})
+    # TODO: Make inds a BooleanIndex
+    if size(inds) != size(da)
+        throw(ArgumentError("Boolean indices must be exhausitive"))
+    end
+    return setindex!(da, val, find(inds))
+end
+
+#' @description
+#'
+#' Insert a value, `val`, of type `Any` into the positions described
+#' by `inds`. The inserted value, `val`, is echoed back as the return
+#' value.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::Any A value to be inserted into the specified entries of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to be modified.
+#'
+#' @returns val::T The value inserted into `da`, converted to the element
+#'          type of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[1, 2]] = 5.0
+function Base.setindex!{T}(da::AbstractDataArray{T},
+                           val::Any,
+                           inds::AbstractVector)
+    val = convert(T, val)
+    for ind in inds
+        da[ind] = val
+    end
+    return val
+end

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -1,3 +1,5 @@
+# TODO: Remove some T's from output type signatures
+
 #' @description
 #'
 #' A type that extends the normal Julia Array{T} type by allowing
@@ -45,7 +47,7 @@ typealias DataMatrix{T} DataArray{T, 2}
 #' Create a DataArray from a set of data values and missingness
 #' mask as an `Array{Bool}`.
 #'
-#' NB: This definitione exist because Julia requires that we redefine
+#' NB: This definition exists because Julia requires that we redefine
 #' inner DataArray constructor as an outer constuctor.
 #' 
 #' @param d::Array The non-NA values of the DataArray being constructed.
@@ -59,7 +61,7 @@ typealias DataMatrix{T} DataArray{T, 2}
 #'
 #' da = DataArray([1, 2, 3], falses(3))
 function DataArray{T, N}(d::Array{T, N},
-                         m::BitArray{N} = falses(size(d)))
+                         m::BitArray{N} = falses(size(d))) # -> DataArray{T}
     return DataArray{T, N}(d, m)
 end
 
@@ -78,18 +80,8 @@ end
 #' @examples
 #'
 #' da = DataArray([1, 2, 3], [false, false, true])
-DataArray(d::Array, m::Array{Bool}) = DataArray(d, bitpack(m))
-
-# TODO: REMOVE
-# Convert a BitArray into a DataArray
-function DataArray(d::BitArray, m::BitArray = falses(size(d)))
-    return DataArray(bitunpack(d), m)
-end
-
-# TODO: REMOVE
-# Convert a Ranges object into a DataVector
-function DataArray(d::Ranges, m::BitArray = falses(length(d)))
-    DataArray(convert(Vector, d), m)
+function DataArray(d::Array, m::Array{Bool}) # -> DataArray{T}
+    return DataArray(d, bitpack(m))
 end
 
 #' @description
@@ -97,7 +89,7 @@ end
 #' Create a DataArray of a given type and dimensionality. All
 #' entries will be set to `NA` by default.
 #' 
-#' @param T::DataType The type of the output DataArray.
+#' @param T::Type The type of the output DataArray.
 #' @param dims::Integer... The size of the output DataArray.
 #'
 #' @returns out::DataArray A DataArray of the desired type and size.
@@ -105,8 +97,8 @@ end
 #' @examples
 #'
 #' da = DataArray(Int, 2, 2)
-function DataArray(t::Type, dims::Integer...)
-    return DataArray(Array(t, dims...), trues(dims...))
+function DataArray(T::Type, dims::Integer...) # -> DataArray{T}
+    return DataArray(Array(T, dims...), trues(dims...))
 end
 
 #' @description
@@ -114,7 +106,7 @@ end
 #' Create a DataArray of a given type and dimensionality. All
 #' entries will be set to `NA` by default.
 #' 
-#' @param T::DataType The type of the output DataArray.
+#' @param T::Type The type of the output DataArray.
 #' @param dims::NTuple{N, Int} The size of the output DataArray.
 #'
 #' @returns out::DataArray A DataArray of the desired type and size.
@@ -122,7 +114,7 @@ end
 #' @examples
 #'
 #' da = DataArray(Int, (2, 2))
-function DataArray{N}(T::DataType, dims::NTuple{N, Int})
+function DataArray{N}(T::Type, dims::NTuple{N, Int}) # -> DataArray{T}
     return DataArray(Array(T, dims...), trues(dims...))
 end
 
@@ -138,7 +130,9 @@ end
 #'
 #' dv = @data [false, false, true, false]
 #' dv_new = copy(dv)
-Base.copy(d::DataArray) = DataArray(copy(d.data), copy(d.na))
+function Base.copy(d::DataArray) # -> DataArray{T}
+    return DataArray(copy(d.data), copy(d.na))
+end
 
 #' @description
 #'
@@ -152,7 +146,9 @@ Base.copy(d::DataArray) = DataArray(copy(d.data), copy(d.na))
 #'
 #' dv = @data [false, false, true, false]
 #' dv_new = deepcopy(dv)
-Base.deepcopy(d::DataArray) = DataArray(deepcopy(d.data), deepcopy(d.na))
+function Base.deepcopy(d::DataArray) # -> DataArray{T}
+    return DataArray(deepcopy(d.data), deepcopy(d.na))
+end
 
 #' @description
 #'
@@ -160,7 +156,7 @@ Base.deepcopy(d::DataArray) = DataArray(deepcopy(d.data), deepcopy(d.na))
 #' 
 #' @param da::DataArray DataArray based on which a new DataArray
 #'        will be created.
-#' @param T::DataType The element type of the output DataArray.
+#' @param T::Type The element type of the output DataArray.
 #' @param dims::Dims The dimensionality of the output DataArray.
 #'
 #' @returns out::DataArray{T} A new DataArray with the desired type and
@@ -201,7 +197,7 @@ Base.size(d::DataArray) = size(d.data) # -> (Int...)
 #'
 #' dm = @data [false false; true false]
 #' inds = ndims(dm)
-Base.ndims(da::DataArray) = ndims(da.data)
+Base.ndims(da::DataArray) = ndims(da.data) # -> Int
 
 #' @description
 #'
@@ -276,7 +272,7 @@ end
 #'
 #' dm = @data [1 2; 3 4]
 #' m = array(dm)
-function array{T}(da::DataArray{T})
+function array{T}(da::DataArray{T}) # -> Array{T}
     res = Array(T, size(da))
     for i in 1:length(da)
         if da.na[i]
@@ -305,7 +301,7 @@ end
 #'
 #' dm = @data [1 2; NA 4]
 #' m = array(dm, 3)
-function array{T}(da::DataArray{T}, replacement::T)
+function array{T}(da::DataArray{T}, replacement::T) # -> Array{T}
     res = Array(T, size(da))
     for i in 1:length(da)
         if da.na[i]
@@ -335,7 +331,7 @@ end
 #'
 #' dm = @data [1 2; NA 4]
 #' m = array(dm, 3)
-function array{T}(da::DataArray{T}, replacement::Any)
+function array{T}(da::DataArray{T}, replacement::Any) # -> Array{T}
     return array(da, convert(T, replacement))
 end
 
@@ -352,7 +348,7 @@ end
 #'
 #' v = [1, 2, 3, 4]
 #' v = dropna(v)
-dropna(v::AbstractVector) = copy(v)
+dropna(v::AbstractVector) = copy(v) # -> AbstractVector
 
 #' @description
 #'
@@ -370,7 +366,7 @@ dropna(v::AbstractVector) = copy(v)
 #'
 #' dv = @data [1, 2, NA, 4]
 #' v = dropna(dv)
-dropna(dv::DataVector) = copy(dv.data[!dv.na])
+dropna(dv::DataVector) = copy(dv.data[!dv.na]) # -> Vector
 
 # Iterators
 # TODO: Use values()
@@ -432,53 +428,190 @@ end
 # Indexing
 
 typealias SingleIndex Real
+# TODO: Remove BitVector here
 typealias MultiIndex Union(Vector, BitVector, Ranges, Range1)
 typealias BooleanIndex Union(BitVector, Vector{Bool})
 
 # TODO: Solve ambiguity warnings here without
 #       ridiculous accumulation of methods
-# v[dv]
-function Base.getindex(x::Vector,
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param v::Vector A Vector whose elements will be retrieved.
+#' @param inds::AbstractDataVector{Bool} An AbstractDataVector
+#'        containing a Boolean mask specifying, for each element,
+#'        whether that element should be retrieved or not. `NA`
+#'        values in the mask are treated as `false`.
+#'
+#' @returns out::Vector The values of `v` at the requested indices.
+#'
+#' @examples
+#'
+#' v = [1, 2, 3]
+#' inds = @data([false, true])
+#' v[inds]
+function Base.getindex(v::Vector,
                        inds::AbstractDataVector{Bool})
-    return x[find(inds)]
-end
-function Base.getindex(x::Vector,
-                       inds::AbstractDataArray{Bool})
-    return x[find(inds)]
-end
-function Base.getindex(x::Array,
-                       inds::AbstractDataVector{Bool})
-    return x[find(inds)]
-end
-function Base.getindex(x::Array,
-                       inds::AbstractDataArray{Bool})
-    return x[find(inds)]
-end
-function Base.getindex{S, T}(x::Vector{S},
-                             inds::AbstractDataArray{T})
-    return x[dropna(inds)]
-end
-function Base.getindex{S, T}(x::Array{S},
-                             inds::AbstractDataArray{T})
-    return x[dropna(inds)]
+    return v[find(inds)]
 end
 
-# d[SingleItemIndex]
-function Base.getindex(d::DataArray, i::SingleIndex)
-	if d.na[i]
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param v::Vector A Vector whose elements will be retrieved.
+#' @param inds::AbstractDataArray{Bool} A DataArray containing
+#'        a Boolean mask specifying, for each element, whether
+#'        that element should be retrieved or not. `NA` values
+#'        in the mask are treated as `false`.
+#'
+#' @returns out::Vector The values of `v` at the requested indices.
+#'
+#' @examples
+#'
+#' v = [1, 2, 3]
+#' inds = @data([false, true])
+#' v[inds]
+function Base.getindex(v::Vector,
+                       inds::AbstractDataArray{Bool})
+    return v[find(inds)]
+end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param a::Array An Array whose elements will be retrieved.
+#' @param inds::AbstractDataArray{Bool} A DataArray containing
+#'        a Boolean mask specifying, for each element, whether
+#'        that element should be retrieved or not. `NA` values
+#'        in the mask are treated as `false`.
+#'
+#' @returns out::Vector{S} The values of `a` at the requested indices.
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' inds = @data([false, true])
+#' a[inds]
+function Base.getindex(a::Array,
+                       inds::AbstractDataArray{Bool})
+    return a[find(inds)]
+end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param a::Vector{S} A Vector whose elements will be retrieved.
+#' @param inds::AbstractDataArray{T} A DataArray containing the indices
+#'        of the requested elements.
+#'
+#' @returns out::Vector{S} The values of `a` at the requested indices.
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' inds = @data([1, 2])
+#' da[1]
+#'
+#' da = @data([NA, 2, 3])
+#' da[1]
+function Base.getindex{S, T}(a::Vector{S},
+                             inds::AbstractDataArray{T})
+    return a[dropna(inds)]
+end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param a::Array{T, N} An Array whose elements will be retrieved.
+#' @param inds::AbstractDataArray{T} A DataArray containing the indices
+#'        of the requested elements.
+#'
+#' @returns out::Array{T} The values of `a` at the requested indices.
+#'
+#' @examples
+#'
+#' a = [1, 2, 3]
+#' inds = @data([1, 2])
+#' da[1]
+#'
+#' da = @data([NA, 2, 3])
+#' da[1]
+function Base.getindex{S, T}(a::Array{S},
+                             inds::AbstractDataArray{T})
+    return a[dropna(inds)]
+end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param ind::Real The index of the element to be retrieved.
+#'
+#' @returns out::Union(T, NAtype) The value of `da` at the requested
+#'          index.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[1]
+#'
+#' da = @data([NA, 2, 3])
+#' da[1]
+function Base.getindex(da::DataArray, ind::SingleIndex)
+	if da.na[ind]
 		return NA
 	else
-		return d.data[i]
+		return da.data[ind]
 	end
 end
 
 # d[MultiItemIndex]
 # TODO: Return SubDataArray
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::AbstractDataVector{Bool} A Boolean mask specifying for
+#'        each element whether that element will be retrieved or not.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' inds = @data([true, false])
+#' da[inds]
 function Base.getindex(d::DataArray,
                        inds::AbstractDataVector{Bool})
     inds = find(inds)
     return d[inds]
 end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::AbstractDataVector The indices of the elements that
+#'        will be retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' inds = @data([1, 2])
+#' da[inds]
 function Base.getindex(d::DataArray,
                        inds::AbstractDataVector)
     inds = dropna(inds)
@@ -488,11 +621,41 @@ end
 # There are two definitions in order to remove ambiguity warnings
 # TODO: Return SubDataArray
 # TODO: Make inds::AbstractVector
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::BooleanIndex A Boolean mask specifying whether each
+#'        element of `da` should be retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[true, false]]
 function Base.getindex{T <: Number, N}(d::DataArray{T,N},
                                        inds::BooleanIndex)
     DataArray(d.data[inds], d.na[inds])
 end
 
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::BooleanIndex A Boolean mask specifying whether each
+#'        element of `da` should be retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[true, false]]
 function Base.getindex(d::DataArray, inds::BooleanIndex)
     res = similar(d, sum(inds))
     j = 1
@@ -507,11 +670,41 @@ function Base.getindex(d::DataArray, inds::BooleanIndex)
     return res
 end
 
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::MultiIndex The indices of the elements of `da` to be
+#'        retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[1, 2]]
 function Base.getindex{T <: Number, N}(d::DataArray{T, N},
                                        inds::MultiIndex)
     return DataArray(d.data[inds], d.na[inds])
 end
 
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::MultiIndex The indices of the elements of `da` to be
+#'        retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[1, 2]]
 function Base.getindex(d::DataArray, inds::MultiIndex)
     res = similar(d, length(inds))
     for i in 1:length(inds)
@@ -529,119 +722,194 @@ end
 # TODO: Make inds::AbstractVector
 ## # The following assumes that T<:Number won't have #undefs
 ## # There are two definitions in order to remove ambiguity warnings
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::BooleanIndex A Boolean mask specifying whether each
+#'        element of `da` should be retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[true, false]]
 function Base.getindex{T <: Number, N}(d::DataArray{T, N},
                                        inds::BooleanIndex)
     DataArray(d.data[inds], d.na[inds])
 end
+
+#' @description
+#'
+#' Get a set of elements of a DataArray.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be retrieved.
+#' @param inds::MultiIndex The indices of the elements of `da` to be
+#'        retrieved.
+#'
+#' @returns out::DataArray{T} A DataArray containing the elements of
+#'          `da` indexed.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[1, 2]]
 function Base.getindex{T <: Number, N}(d::DataArray{T, N},
                                        inds::MultiIndex)
     DataArray(d.data[inds], d.na[inds])
 end
 
-# setindex!()
-
-# d[SingleItemIndex] = NA
-function Base.setindex!(da::DataArray, val::NAtype, i::SingleIndex)
+#' @description
+#'
+#' Set one element of a DataArray to `NA`.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be modified.
+#' @param val::NAtype The `NA` value being assigned to an element of `da`.
+#' @param ind::Real A real value specifying the index of the element
+#'        of `da` being modified.
+#'
+#' @returns val::NAtype The `NA` value that was assigned to an element
+#'          of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[1] = NA
+function Base.setindex!(da::DataArray,
+                        val::NAtype,
+                        i::SingleIndex) # -> NAtype
 	da.na[i] = true
     return NA
 end
 
-# d[SingleItemIndex] = Single Item
-function Base.setindex!(da::DataArray, val::Any, i::SingleIndex)
-	da.data[i] = val
-	da.na[i] = false
+#' @description
+#'
+#' Set one element of a DataArray to a new value, `val`.
+#'
+#' @param da::DataArray{T, N} A DataArray whose element will be modified.
+#' @param val::Any The value being assigned to an element of `da`.
+#' @param ind::Real A real value specifying the index of the element
+#'        of `da` being modified.
+#'
+#' @returns val::Any The value that was assigned to an element of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[1] = 4
+function Base.setindex!(da::DataArray,
+                        val::Any,
+                        ind::SingleIndex) # -> Any
+	da.data[ind] = val
+	da.na[ind] = false
     return val
 end
 
-# d[MultiIndex] = NA
-function Base.setindex!(da::DataArray{NAtype},
-                        val::NAtype,
-                        inds::AbstractVector{Bool})
-    throw(ArgumentError("DataArray{NAtype} is incoherent"))
-end
-function Base.setindex!(da::DataArray{NAtype},
-                        val::NAtype,
-                        inds::AbstractVector)
-    throw(ArgumentError("DataArray{NAtype} is incoherent"))
-end
+#' @description
+#'
+#' Set a specified set of elements of a DataArray to `NA`.
+#'
+#' NB: The indices in `inds` must be exhaustive.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::NAtype The NA value being assigned to elements of `da`.
+#' @param inds::AbstractVector{Bool} A Boolean vector specifying for every
+#'        element of `da` whether it will be modified.
+#'
+#' @returns val::NAtype The NA value that was assigned to elements of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[[true, false, true]] = NA
 function Base.setindex!(da::DataArray,
                         val::NAtype,
-                        inds::AbstractVector{Bool})
+                        inds::AbstractVector{Bool}) # -> NAtype
     da.na[find(inds)] = true
     return NA
 end
+
+#' @description
+#'
+#' Set a specified set of elements of a DataArray to `NA`.
+#'
+#' @param da::DataArray{T, N} A DataArray whose entries will be modified.
+#' @param val::NAtype The NA value being assigned to elements of `da`.
+#' @param inds::AbstractVector A vector of indices of `da` to
+#'        be modified.
+#'
+#' @returns val::NAtype The NA value that was assigned to elements of `da`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' da[1:3] = NA
 function Base.setindex!(da::DataArray,
                         val::NAtype,
-                        inds::AbstractVector)
+                        inds::AbstractVector) # -> NAtype
     da.na[inds] = true
     return NA
 end
 
-# d[MultiIndex] = Multiple Values
-function Base.setindex!(da::AbstractDataArray,
-                        vals::AbstractVector,
-                        inds::AbstractVector{Bool})
-    setindex!(da, vals, find(inds))
+#' @description
+#'
+#' Determine if the entries of an DataArray are `NA`.
+#'
+#' @param a::DataArray{T, N} The DataArray whose missingness will
+#'        be assessed.
+#'
+#' @returns na::BitArray{N} Elementwise Boolean whether entry is missing.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' isna(da)
+isna(da::DataArray) = copy(da.na) # -> BitArray
+
+#' @description
+#'
+#' Determine if the entries of an DataArray are `NaN`.
+#'
+#' @param a::DataArray{T, N} The DataArray whose elements will
+#'        be assessed.
+#'
+#' @returns na::DataArray{Bool} Elementwise Boolean whether entry is `NaN`.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' isnan(da)
+function Base.isnan(da::DataArray) # -> DataArray{Bool}
+    return DataArray(isnan(da.data), copy(da.na))
 end
-function Base.setindex!(da::AbstractDataArray,
-                        vals::AbstractVector,
-                        inds::AbstractVector)
-    for (val, ind) in zip(vals, inds)
-        da[ind] = val
+
+#' @description
+#'
+#' Determine if the entries of an DataArray are finite, which means
+#' neither `+/-NaN` nor `+/-Inf`.
+#'
+#' @param a::DataArray{T, N} The DataArray whose elements will
+#'        be assessed.
+#'
+#' @returns na::DataArray{Bool} Elementwise Boolean whether entry is finite.
+#'
+#' @examples
+#'
+#' da = @data([1, 2, 3])
+#' isfinite(da)
+function Base.isfinite(da::DataArray) # -> DataArray{Bool}
+    n = length(da)
+    res = Array(Bool, size(da))
+    for i in 1:n
+        if !da.na[i]
+            res[i] = isfinite(da.data[i])
+        end
     end
-    return vals
+    return DataArray(res, copy(da.na))
 end
-
-# x[MultiIndex] = Single Item
-function Base.setindex!{T}(da::AbstractDataArray{T},
-                           val::Union(Number, String, T),
-                           inds::AbstractVector{Bool})
-    setindex!(da, val, find(inds))
-end
-function Base.setindex!{T}(da::AbstractDataArray{T},
-                           val::Union(Number, String, T),
-                           inds::AbstractVector)
-    val = convert(T, val)
-    for ind in inds
-        da[ind] = val
-    end
-    return val
-end
-function Base.setindex!(da::AbstractDataArray,
-                        val::Any,
-                        inds::AbstractVector{Bool})
-    setindex!(da, val, find(inds))
-end
-function Base.setindex!{T}(da::AbstractDataArray{T},
-                           val::Any,
-                           inds::AbstractVector)
-    val = convert(T, val)
-    for ind in inds
-        da[ind] = val
-    end
-    return val
-end
-
-# Predicates
-
-isna(a::AbstractArray) = falses(size(a))
-isna(da::DataArray) = copy(da.na)
-
-Base.isnan(da::DataArray) = DataArray(isnan(da.data), copy(da.na))
-
-Base.isfinite(da::DataArray) = DataArray(isfinite(da.data), copy(da.na))
-
-anyna(a::AbstractArray) = false
-anyna(d::AbstractDataArray) = any(isna, d)
-
-allna(a::AbstractArray) = false
-allna(d::AbstractDataArray) = all(isna, d)
-
-# Generic iteration over AbstractDataArray's
-
-Base.start(x::AbstractDataArray) = 1
-Base.next(x::AbstractDataArray, state::Integer) = (x[state], state + 1)
-Base.done(x::AbstractDataArray, state::Integer) = state > length(x)
 
 # Promotion rules
 
@@ -668,7 +936,8 @@ Base.done(x::AbstractDataArray, state::Integer) = state > length(x)
 #'
 #' da = @data [1 2; 3 4]
 #' a = convert(Array{Float64}, da)
-function Base.convert{S, T, N}(::Type{Array{S, N}}, x::DataArray{T, N})
+function Base.convert{S, T, N}(::Type{Array{S, N}},
+                               x::DataArray{T, N}) # -> Array{S, N}
     if anyna(x)
         err = "Cannot convert DataArray with NA's to desired type"
         throw(NAException(err))
@@ -693,7 +962,9 @@ end
 #'
 #' da = @data [1 2; 3 4]
 #' a = convert(Array, da)
-function Base.convert{T, N}(::Type{Array}, x::DataArray{T, N})
+# TODO: Consider making a copy here
+function Base.convert{T, N}(::Type{Array},
+                            x::DataArray{T, N}) # -> Array{T}
     if anyna(x)
         err = "Cannot convert DataArray with NA's to base type"
         throw(NAException(err))
@@ -715,8 +986,9 @@ end
 #'
 #' a = [1 2; 3 4]
 #' da = convert(DataArray{Float64}, a)
-function Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::Array{T, N})
-    return DataArray(convert(Array{S}, x), falses(size(x)))
+function Base.convert{S, T, N}(::Type{DataArray{S, N}},
+                               a::AbstractArray{T, N}) # -> DataArray{S, N}
+    return DataArray(convert(Array{S, N}, a), falses(size(a)))
 end
 
 #' @description
@@ -731,8 +1003,9 @@ end
 #'
 #' a = [1 2; 3 4]
 #' da = convert(DataArray, a)
-function Base.convert{T, N}(::Type{DataArray}, a::Array{T, N})
-    return DataArray(a, falses(size(a)))
+function Base.convert{T, N}(::Type{DataArray},
+                            a::AbstractArray{T, N}) # -> DataArray{T, N}
+    return DataArray(convert(Array{T, N}, a), falses(size(a)))
 end
 
 #' @description
@@ -747,13 +1020,15 @@ end
 #'
 #' dv = @data [1, 2, NA, 4]
 #' dv_alt = convert(DataVector{Float64}, dv)
-function Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::DataArray{T, N})
+function Base.convert{S, T, N}(::Type{DataArray{S, N}},
+                               x::DataArray{T, N}) # -> DataArray{S, N}
     return DataArray(convert(Array{S}, x.data), x.na)
 end
 
 #' @description
 #'
 #' NO-OP: See convert(DataArray{S}, DataArray{T}) for rationale.
+#' TODO: Make operative by doing copy?
 #'
 #' @param da::DataArray{T} The DataArray that will be converted.
 #'
@@ -763,7 +1038,8 @@ end
 #'
 #' dv = @data [1, 2, NA, 4]
 #' dv_alt = convert(DataVector, dv)
-function Base.convert{T, N}(::Type{DataArray}, x::DataArray{T, N})
+function Base.convert{T, N}(::Type{DataArray},
+                            x::DataArray{T, N}) # -> DataArray{T, N}
     return DataArray(x.data, x.na)
 end
 
@@ -784,10 +1060,11 @@ end
 #' v = bool(dv)
 #
 # TODO: Make sure these handle copying correctly
+# TODO: Remove these? They have odd behavior, because they convert to Array's.
 # TODO: Rethink multi-item documentation approach
 for f in (:(Base.int), :(Base.float), :(Base.bool))
     @eval begin
-        function ($f)(da::DataArray)
+        function ($f)(da::DataArray) # -> DataArray
             if anyna(da)
                 err = "Cannot convert DataArray with NA's to desired type"
                 throw(NAException(err))

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -754,35 +754,41 @@ function PooledDataVecs(v1::AbstractArray,
             PooledDataArray(RefArray(refs2), pool))
 end
 
-function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}}, x::Array{T, N})
-    return PooledDataArray(convert(Array{S}, x), falses(size(x)))
+function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}},
+                               a::AbstractArray{T, N})
+    return PooledDataArray(convert(Array{S, N}, a), falses(size(a)))
 end
 
-function Base.convert{T, N}(::Type{PooledDataArray}, x::Array{T, N})
-    return PooledDataArray(x, falses(size(x)))
+function Base.convert{T, N}(::Type{PooledDataArray}, a::AbstractArray{T, N})
+    return PooledDataArray(convert(Array{T, N}, a), falses(size(a)))
 end
 
-function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}}, x::DataArray{T, N})
-    return PooledDataArray(convert(Array{S}, x.data), x.na)
+function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}},
+                               da::DataArray{T, N})
+    return PooledDataArray(convert(Array{S, N}, da.data), da.na)
 end
 
-function Base.convert{T, N}(::Type{PooledDataArray}, x::DataArray{T, N})
-    return PooledDataArray(x.data, x.na)
+function Base.convert{T, N}(::Type{PooledDataArray}, da::DataArray{T, N})
+    return PooledDataArray(da.data, da.na)
 end
 
-function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}}, x::PooledDataArray{T, N})
-    return PooledDataArray(RefArray(copy(x.refs)), convert(Array{S}, x.pool))
+function Base.convert{S, T, N}(::Type{PooledDataArray{S, N}},
+                               pda::PooledDataArray{T, N})
+    return PooledDataArray(RefArray(copy(pda.refs)),
+                           convert(Array{S, N}, pda.pool))
 end
 
-function Base.convert{T, N}(::Type{PooledDataArray}, x::PooledDataArray{T, N})
-    return PooledDataArray(RefArray(copy(x.refs)), copy(x.pool))
+function Base.convert{T, N}(::Type{PooledDataArray},
+                            pda::PooledDataArray{T, N})
+    return PooledDataArray(RefArray(pda.refs), pda.pool)
 end
 
-function Base.convert{S, T, N}(::Type{DataArray{S, N}}, pda::PooledDataArray{T, N})
+function Base.convert{S, T, N}(::Type{DataArray{S, N}},
+                               pda::PooledDataArray{T, N})
     res = DataArray(Array(S, size(pda)), BitArray(size(pda)))
     for i in 1:length(pda)
         r = pda.refs[i]
-        if r == 0
+        if r == 0 # TODO: Use zero(R)
             res.na[i] = true
         else
             res.na[i] = false

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -19,30 +19,35 @@ module TestConstructors
 	@assert isequal(dv, DataArray([1, 2, 3], [false, false, false]))
 	@assert isequal(dv, DataArray([1, 2, 3]))
 
-	dv = DataArray(trues(3), falses(3))
+	dv = convert(DataArray, trues(3))
 	@assert isequal(dv.data, [true, true, true])
 	@assert isequal(dv.na, falses(3))
-	@assert isequal(dv, DataArray(trues(3)))
+	@assert isequal(dv, convert(DataArray, trues(3)))
 
 	dv = DataArray([1, 2, 3], falses(3))
-	@assert isequal(dv, DataArray(1:3))
+	@assert isequal(dv, convert(DataArray, 1:3))
 
 	dv = DataArray(Int, 3)
 	@assert isequal(eltype(dv), Int)
 	@assert isequal(dv.na, trues(3))
 
-	dv = @data zeros(3)
-	@assert isequal(dv, DataArray(zeros(3)))
-	dv = @data zeros(Int, 3)
-	@assert isequal(dv, DataArray(zeros(Int, 3)))
-	dv = @data ones(3)
-	@assert isequal(dv, DataArray(ones(3)))
-	dv = @data ones(Int, 3)
-	@assert isequal(dv, DataArray(ones(Int, 3)))
-	dv = @data falses(3)
-	@assert isequal(dv, DataArray(falses(3)))
-	dv = @data trues(3)
-	@assert isequal(dv, DataArray(trues(3)))
+	dv = convert(DataArray, zeros(3))
+	@assert isequal(dv, convert(DataArray, zeros(3)))
+
+	dv = convert(DataArray, zeros(Int, 3))
+	@assert isequal(dv, convert(DataArray, zeros(Int, 3)))
+
+	dv = convert(DataArray, ones(3))
+	@assert isequal(dv, convert(DataArray, ones(3)))
+
+	dv = convert(DataArray, ones(Int, 3))
+	@assert isequal(dv, convert(DataArray, ones(Int, 3)))
+
+	dv = convert(DataArray, falses(3))
+	@assert isequal(dv, convert(DataArray, falses(3)))
+
+	dv = convert(DataArray, trues(3))
+	@assert isequal(dv, convert(DataArray, trues(3)))
 
 	#
 	# PooledDataArray's
@@ -55,31 +60,36 @@ module TestConstructors
 	@assert isequal(pdv, PooledDataArray([1, 2, 3], [false, false, false]))
 	@assert isequal(pdv, PooledDataArray([1, 2, 3]))
 
-	pdv = PooledDataArray(trues(3), falses(3))
+	pdv = convert(PooledDataArray, trues(3))
 	@assert all(pdv .== [true, true, true])
 	@assert all(isna(pdv) .== falses(3))
-	@assert isequal(pdv, PooledDataArray(trues(3)))
+	@assert isequal(pdv, convert(PooledDataArray, trues(3)))
 
 	pdv = PooledDataArray([1, 2, 3], falses(3))
-	@assert isequal(pdv, PooledDataArray(1:3))
-	@assert isequal(pdv, PooledDataArray(PooledDataArray([1, 2, 3])))
+	@assert isequal(pdv, convert(PooledDataArray, 1:3))
+	@assert isequal(pdv, convert(PooledDataArray, PooledDataArray([1, 2, 3])))
 
 	pdv = PooledDataArray(Int, 3)
 	@assert isequal(eltype(pdv), Int)
 	@assert all(isna(pdv) .== trues(3))
 
-	pdv = @pdata zeros(3)
-	@assert isequal(pdv, PooledDataArray(zeros(3)))
-	pdv = @pdata zeros(Int, 3)
-	@assert isequal(pdv, PooledDataArray(zeros(Int, 3)))
-	pdv = @pdata ones(3)
-	@assert isequal(pdv, PooledDataArray(ones(3)))
-	pdv = @pdata ones(Int, 3)
-	@assert isequal(pdv, PooledDataArray(ones(Int, 3)))
-	pdv = @pdata falses(3)
-	@assert isequal(pdv, PooledDataArray(falses(3)))
-	pdv = @pdata trues(3)
-	@assert isequal(pdv, PooledDataArray(trues(3)))
+	pdv = convert(PooledDataArray, zeros(3))
+	@assert isequal(pdv, convert(PooledDataArray, zeros(3)))
+
+	pdv = convert(PooledDataArray, zeros(Int, 3))
+	@assert isequal(pdv, convert(PooledDataArray, zeros(Int, 3)))
+
+	pdv = convert(PooledDataArray, ones(3))
+	@assert isequal(pdv, convert(PooledDataArray, ones(3)))
+
+	pdv = convert(PooledDataArray, ones(Int, 3))
+	@assert isequal(pdv, convert(PooledDataArray, ones(Int, 3)))
+
+	pdv = convert(PooledDataArray, falses(3))
+	@assert isequal(pdv, convert(PooledDataArray, falses(3)))
+
+	pdv = convert(PooledDataArray, trues(3))
+	@assert isequal(pdv, convert(PooledDataArray, trues(3)))
 
 	#
 	# DataMatrix
@@ -92,26 +102,27 @@ module TestConstructors
 	@assert isequal(dm, DataArray([1 2; 3 4], [false false; false false]))
 	@assert isequal(dm, DataArray([1 2; 3 4]))
 
-	dm = DataArray(trues(2, 2), falses(2, 2))
+	dm = convert(DataArray, trues(2, 2))
 	@assert isequal(dm.data, trues(2, 2))
 	@assert isequal(dm.na, falses(2, 2))
 
-	@assert isequal(dm, DataArray(trues(2, 2)))
+	@assert isequal(dm, convert(DataArray, trues(2, 2)))
 
 	dm = DataArray(Int, 2, 2)
 	@assert isequal(eltype(dm), Int)
 	@assert isequal(dm.na, trues(2, 2))
 
-	@assert isequal((@data zeros(2, 2)), DataArray(zeros(2, 2)))
-	@assert isequal((@data zeros(Int, 2, 2)), DataArray(zeros(Int, 2, 2)))
+	convert(DataArray, zeros(2, 2))
 
-	@assert isequal((@data ones(2, 2)), DataArray(ones(2, 2)))
-	@assert isequal((@data ones(Int, 2, 2)), DataArray(ones(Int, 2, 2)))
+	convert(DataArray, zeros(Int, 2, 2))
 
-	@assert isequal((@data falses(2, 2)), DataArray(falses(2, 2)))
-	@assert isequal((@data trues(2, 2)), DataArray(trues(2, 2)))
+	convert(DataArray, ones(2, 2))
+	convert(DataArray, ones(Int, 2, 2))
 
-	@assert isequal((@data eye(3, 2)), DataArray(eye(3, 2)))
-	@assert isequal((@data eye(2)), DataArray(eye(2)))
-	@assert isequal((@data diagm(Float64[pi, pi])), DataArray(diagm(Float64[pi, pi])))
+	convert(DataArray, falses(2, 2))
+	convert(DataArray, trues(2, 2))
+
+	convert(DataArray, eye(3, 2))
+	convert(DataArray, eye(2))
+	convert(DataArray, diagm(Float64[pi, pi]))
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -14,10 +14,10 @@ module TestData
     #test_group("DataVector creation")
     dvint = @data [1, 2, NA, 4]
     dvint2 = DataArray([5:8])
-    dvint3 = DataArray(5:8)
+    dvint3 = convert(DataArray, 5:8)
     dvflt = @data [1.0, 2, NA, 4]
     dvstr = @data ["one", "two", NA, "four"]
-    dvdict = DataArray(Dict,4)    # for issue #199
+    dvdict = DataArray(Dict, 4) # for issue #199
 
     @assert isa(dvint, DataVector{Int})
     @assert isa(dvint2, DataVector{Int})
@@ -40,11 +40,13 @@ module TestData
     @assert isequal(pdvpp.pool, [1, 2, 3, 4])
     @assert string(pdvpp) == "[1, 2, 2, 3, 2, 1]"
     pdvpp = PooledDataArray(["one", "two", "two"], ["one", "two", "three"])
-    @assert isequal(convert(DataArray, pdvpp), (@data ["one", "two", "two"]))
-    @assert isequal(levels(pdvpp), (@data ["one", "two", "three"]))
+    @assert isequal(convert(DataArray, pdvpp), @data(["one", "two", "two"]))
+    @assert isequal(levels(pdvpp), @data(["one", "two", "three"]))
     @assert isequal(pdvpp.pool, ["one", "two", "three"])
     @assert string(pdvpp) == "[one, two, two]"
-    @assert string(PooledDataArray(["one", "two", "four"], ["one", "two", "three"])) == "[one, two, NA]"
+    @assert string(PooledDataArray(["one", "two", "four"],
+                                   ["one", "two", "three"])) ==
+            "[one, two, NA]"
 
     #test_group("PooledDataVector utf8 support")
     pdvpp = PooledDataArray([utf8("hello")], [false])
@@ -55,18 +57,19 @@ module TestData
     #test_group("DataVector access")
     @assert dvint[1] == 1
     @assert isna(dvint[3])
-    @assert isequal(dvflt[3:4], (@data [NA, 4.0]))
-    @assert isequal(dvint[[true, false, true, false]], (@data [1, NA]))
-    @assert isequal(dvstr[[1, 2, 1, 4]], (@data ["one", "two", "one", "four"]))
+    @assert isequal(dvflt[3:4], @data([NA, 4.0]))
+    @assert isequal(dvint[[true, false, true, false]], @data([1, NA]))
+    @assert isequal(dvstr[[1, 2, 1, 4]], @data(["one", "two", "one", "four"]))
     # Indexing produces #undef?
     # @assert isequal(dvstr[[1, 2, 1, 3]], DataVector["one", "two", "one", NA])
 
     #test_group("PooledDataVector access")
     @assert pdvstr[1] == "one"
     @assert isna(pdvstr[5])
-    @assert isequal(pdvstr[1:3], (@data ["one", "one", "two"]))
-    @assert isequal(pdvstr[[true, false, true, false, true, false, true]], (@pdata ["one", "two", NA, "one"]))
-    @assert isequal(pdvstr[[1, 3, 1, 2]], (@data ["one", "two", "one", "one"]))
+    @assert isequal(pdvstr[1:3], @data(["one", "one", "two"]))
+    @assert isequal(pdvstr[[true, false, true, false, true, false, true]],
+                    @pdata(["one", "two", NA, "one"]))
+    @assert isequal(pdvstr[[1, 3, 1, 2]], @data(["one", "two", "one", "one"]))
 
     #test_group("DataVector methods")
     @assert size(dvint) == (4,)
@@ -82,9 +85,9 @@ module TestData
 
     #test_group("DataVector operations")
     @assert isequal(dvint + 1, DataArray([2, 3, 4, 5], [false, false, true, false]))
-    @assert isequal(dvint .* 2, (@data [2, 4, NA, 8]))
-    @assert isequal(dvint .== 2, (@data [false, true, NA, false]))
-    @assert isequal(dvint .> 1, (@data [false, true, NA, true]))
+    @assert isequal(dvint .* 2, @data([2, 4, NA, 8]))
+    @assert isequal(dvint .== 2, @data([false, true, NA, false]))
+    @assert isequal(dvint .> 1, @data([false, true, NA, true]))
 
     #test_group("PooledDataVector operations")
     # @assert isequal(pdvstr .== "two", PooledDataVector[false, false, true, true, NA, false, false])

--- a/test/newtests/dataarray.jl
+++ b/test/newtests/dataarray.jl
@@ -38,19 +38,16 @@ module TestDataArrays
 	DataArray(['a', 'b'], [true, true])
 
 	# DataArray(d::BitArray, m::BitArray = falses(size(d)))
-	DataArray(falses(2), falses(2))
-	DataArray(trues(2), falses(2))
-
-	DataArray(falses(2), trues(2))
-	DataArray(trues(2), trues(2))
+	convert(DataArray, falses(2))
+	convert(DataArray, trues(2))
 
 	# DataArray(d::BitArray, m::BitArray = falses(size(d)))
-	DataArray(falses(2))
-	DataArray(trues(2))
+	convert(DataArray, falses(2))
+	convert(DataArray, trues(2))
 
 	# DataArray(d::Ranges, m::BitArray = falses(length(d)))
-	DataArray(1:2, falses(2))
-	DataArray(1:2, trues(2))
+	convert(DataArray, 1:2)
+	convert(DataArray, 1:2)
 
 	# DataArray(t::Type, dims::Integer...)
 	DataArray(Float64, 2)
@@ -236,7 +233,7 @@ module TestDataArrays
 
 	# Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector{Bool})
 	da = @data([1, 2])
-	da[[true, false]] = [3, 4]
+	da[[true, false]] = [3]
 
 	# Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector)
 	da = @data([1, 2])

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -60,7 +60,7 @@ module TestOperators
             end
         end
     end
-    dv = @data trues(5)
+    dv = convert(DataArray, trues(5))
     @test_da_pda dv begin
         for f in map(eval, DataArrays.logical_unary_operators)
             for i in 1:length(dv)
@@ -70,7 +70,7 @@ module TestOperators
     end
 
     # Elementary functions on DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     @test_da_pda dv begin
         for f in map(eval, DataArrays.elementary_functions)
             for i in 1:length(dv)
@@ -80,7 +80,7 @@ module TestOperators
     end
 
     # Broadcasting operations between NA's and DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     @test_da_pda dv begin
         for f in map(eval, DataArrays.arithmetic_operators)
             for i in 1:length(dv)
@@ -91,7 +91,7 @@ module TestOperators
     end
 
     # Broadcasting operations between scalars and DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     @test_da_pda dv begin
         for f in map(eval, DataArrays.arithmetic_operators)
             for i in 1:length(dv)
@@ -100,7 +100,7 @@ module TestOperators
             end
         end
     end
-    dv = @data [false, true, false, true, false]
+    dv = @data([false, true, false, true, false])
     for f in map(eval, DataArrays.bit_operators)
         for i in 1:length(dv)
             @assert f(dv, true)[i] == f(dv[i], true)
@@ -110,7 +110,7 @@ module TestOperators
 
     # Binary operations on (DataVector, Vector) or (Vector, DataVector)
     v = ones(5)
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     dv[1] = NA
     @test_da_pda dv begin
         for f in map(eval, DataArrays.array_arithmetic_operators)
@@ -124,7 +124,7 @@ module TestOperators
     end
 
     # Binary operations on pairs of DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     dv[1] = NA
     @test_da_pda dv begin
         for f in map(eval, DataArrays.array_arithmetic_operators)
@@ -136,7 +136,9 @@ module TestOperators
     end
 
     # Division (special case since return type for Int is a Float64)
-    for curdv in (dv, convert(DataVector{Int}, dv), convert(DataVector{Float32}, dv))
+    for curdv in (dv,
+                  convert(DataVector{Int}, dv),
+                  convert(DataVector{Float32}, dv))
         for i in 1:length(curdv)
             @assert isna((curdv./curdv)[i]) && isna(curdv[i]) ||
                     isequal((curdv./curdv)[i], (curdv[i]./curdv[i]))
@@ -148,7 +150,7 @@ module TestOperators
     end
     
     # Unary vector operators on DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.unary_vector_operators)
         @assert isequal(f(dv), f(dv.data))
     end
@@ -158,24 +160,24 @@ module TestOperators
     end
 
     # Pairwise vector operators on DataVector's
-    dv = @data [911, 269, 835.0, 448, 772]
+    dv = @data([911, 269, 835.0, 448, 772])
     for f in map(eval, DataArrays.pairwise_vector_operators)
         @assert isequal(f(dv), f(dv.data))
     end
-    dv = @data [NA, 269, 835.0, 448, 772]
+    dv = @data([NA, 269, 835.0, 448, 772])
     for f in map(eval, DataArrays.pairwise_vector_operators)
         v = f(dv)
         @assert isna(v[1])
         @assert isequal(v[2:4], f(dv.data)[2:4])
     end
-    dv = @data [911, NA, 835.0, 448, 772]
+    dv = @data([911, NA, 835.0, 448, 772])
     for f in map(eval, DataArrays.pairwise_vector_operators)
         v = f(dv)
         @assert isna(v[1])
         @assert isna(v[2])
         @assert isequal(v[3:4], f(dv.data)[3:4])
     end
-    dv = @data [911, 269, 835.0, 448, NA]
+    dv = @data([911, 269, 835.0, 448, NA])
     for f in map(eval, DataArrays.pairwise_vector_operators)
         v = f(dv)
         @assert isna(v[4])
@@ -183,7 +185,7 @@ module TestOperators
     end
 
     # Cumulative vector operators on DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.cumulative_vector_operators)
         for i in 1:length(dv)
             @assert f(dv)[i] == f(dv.data)[i]
@@ -200,7 +202,7 @@ module TestOperators
     end
 
     # FFT's on DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.ffts)
         @assert f(dv) == f(dv.data)
     end
@@ -210,7 +212,7 @@ module TestOperators
     end
 
     # Binary vector operators on DataVector's
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.binary_vector_operators)
         @assert f(dv, dv) == f(dv.data, dv.data) ||
                 (isnan(f(dv, dv)) && isnan(f(dv.data, dv.data)))
@@ -221,30 +223,30 @@ module TestOperators
     end
 
     # Boolean operators on DataVector's
-    @assert any((@data falses(5))) == false
-    @assert any((@data trues(5))) == true
-    @assert all((@data falses(5))) == false
-    @assert all((@data trues(5))) == true
-    @assert any(PooledDataArray((@data falses(5)))) == false
-    @assert any(PooledDataArray((@data trues(5)))) == true
-    @assert all(PooledDataArray((@data falses(5)))) == false
-    @assert all(PooledDataArray((@data trues(5)))) == true
+    @assert any(convert(DataArray, falses(5))) == false
+    @assert any(convert(DataArray, trues(5))) == true
+    @assert all(convert(DataArray, falses(5))) == false
+    @assert all(convert(DataArray, trues(5))) == true
+    @assert any(PooledDataArray(convert(DataArray, falses(5)))) == false
+    @assert any(PooledDataArray(convert(DataArray, trues(5)))) == true
+    @assert all(PooledDataArray(convert(DataArray, falses(5)))) == false
+    @assert all(PooledDataArray(convert(DataArray, trues(5)))) == true
 
-    dv = @data falses(5)
+    dv = convert(DataArray, falses(5))
     dv[3] = true
     @test_da_pda dv begin
         @assert any(dv) == true
         @assert all(dv) == false
     end
 
-    dv = @data falses(5)
+    dv = convert(DataArray, falses(5))
     dv[1] = NA
     @test_da_pda dv begin
         @assert isna(any(dv))
         @assert all(dv) == false
     end
 
-    dv = @data falses(5)
+    dv = convert(DataArray, falses(5))
     dv[2] = NA
     dv[3] = true
     @test_da_pda dv begin
@@ -252,28 +254,28 @@ module TestOperators
         @assert all(dv) == false
     end
 
-    dv = @data falses(5)
+    dv = convert(DataArray, falses(5))
     dv[2] = NA
     @test_da_pda dv begin
         @assert isna(any(dv))
         @assert all(dv) == false
     end
 
-    dv = @data falses(1)
+    dv = convert(DataArray, falses(1))
     dv[1] = NA
     @test_da_pda dv begin
         @assert isna(any(dv))
         @assert isna(all(dv))
     end
 
-    dv = @data trues(5)
+    dv = convert(DataArray, trues(5))
     dv[1] = NA
     @test_da_pda dv begin
         @assert any(dv) == true
         @assert isna(all(dv))
     end
 
-    dv = @data trues(5)
+    dv = convert(DataArray, trues(5))
     dv[2] = NA
     @test_da_pda dv begin
         @assert any(dv) == true
@@ -285,10 +287,10 @@ module TestOperators
     #
 
     v = [1, 2]
-    dv = @data [1, NA]
-    alt_dv = @data [2, NA]
-    pdv = PooledDataArray(@data [1, NA])
-    alt_pdv = PooledDataArray(@data [2, NA])
+    dv = @data([1, NA])
+    alt_dv = @data([2, NA])
+    pdv = convert(PooledDataArray, @data([1, NA]))
+    alt_pdv = convert(PooledDataArray, @data([2, NA]))
 
     @assert isna(NA == NA)
     @assert isna(NA != NA)
@@ -315,11 +317,11 @@ module TestOperators
     # Comparing two otherwise equal DataArray with NAs returns NA
     test_da_eq(dv, dv, NA)
     test_da_eq(dv, v, NA)
-    test_da_eq(dv, (@data [NA, 1]), NA)
+    test_da_eq(dv, @data([NA, 1]), NA)
     # Comparing two equal arrays with no NAs returns true
     test_da_eq(v, v, true)
     # Comparing two unequal arrays with no NAs returns false
-    test_da_eq(v, (@data [1, 3]), false)
+    test_da_eq(v, @data([1, 3]), false)
     # Comparing two otherwise unequal arrays with NAs returns false
     test_da_eq(dv, alt_dv, false)
     # Comparing two arrays of unequal sizes returns false
@@ -331,21 +333,21 @@ module TestOperators
     @assert !isequal(dv, alt_dv)
     @assert !isequal(pdv, alt_pdv)
 
-    @assert isequal((@data [1, NA]) .== (@data [1, NA]), (@data [true, NA]))
-    @assert isequal((@pdata [1, NA]) .== (@pdata [1, NA]), (@data [true, NA]))
+    @assert isequal(@data([1, NA]) .== @data([1, NA]), @data([true, NA]))
+    @assert isequal(@pdata([1, NA]) .== @pdata([1, NA]), @data([true, NA]))
 
-    @assert all(isna(NA .== (@data ones(5))))
-    @assert all(isna((@data ones(5)) .== NA))
-    @assert all(isna(NA .== PooledDataArray((@data ones(5)))))
-    @assert all(isna(PooledDataArray((@data ones(5))) .== NA))
+    @assert all(isna(NA .== convert(DataArray, ones(5))))
+    @assert allna(isna(convert(DataArray, ones(5))) .== NA)
+    @assert all(isna(NA .== PooledDataArray(convert(DataArray, ones(5)))))
+    @assert allna(isna(convert(PooledDataArray, convert(DataArray, ones(5)))) .== NA)
 
     # Run length encoding
-    dv = @data ones(5)
+    dv = convert(DataArray, ones(5))
     dv[3] = NA
 
     v, l = DataArrays.rle(dv)
-    @assert isequal(v, (@data [1.0, NA, 1.0]))
-    @assert (l == [2, 1, 2])
+    @assert isequal(v, @data([1.0, NA, 1.0]))
+    @assert l == [2, 1, 2]
 
     rdv = DataArrays.inverse_rle(v, l)
     @assert isequal(dv, rdv)


### PR DESCRIPTION
This PR drops some of the constructors that we've used which have no analogue in the Array code in Base.

At the same time, it fix a few of the conversion methods to do work previously done by constructors. This is also consistent with the approach in Base.
