### PR TITLE
Make setindex! return the updated DataArray

### DIFF
--- a/src/abstractdataarray.jl
+++ b/src/abstractdataarray.jl
@@ -146,7 +146,7 @@ isna(a::AbstractArray, i::Real) = false # -> Bool
 #' @param inds::AbstractVector A vector of indices of `da` to
 #'        be modified.
 #'
-#' @returns vals::AbstractVector The values inserted into `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -173,7 +173,7 @@ end
 #' @param inds::AbstractVector A vector of indices of `da` to
 #'        be modified.
 #'
-#' @returns vals::AbstractVector The values inserted into `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -188,7 +188,7 @@ function Base.setindex!(da::AbstractDataArray,
     for (val, ind) in zip(vals, inds)
         da[ind] = val
     end
-    return vals
+    return da
 end
 
 #' @description
@@ -204,8 +204,7 @@ end
 #' @param inds::AbstractVector{Bool} A Boolean vector of indices of `da` to
 #'        be modified.
 #'
-#' @returns val::T The value inserted into `da`, converted to the element
-#'          type of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -229,8 +228,7 @@ end
 #' @param val::Any A value to be inserted into the specified entries of `da`.
 #' @param inds::AbstractVector A vector of indices of `da` to be modified.
 #'
-#' @returns val::T The value inserted into `da`, converted to the element
-#'          type of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -243,7 +241,7 @@ function Base.setindex!{T}(da::AbstractDataArray{T},
     for ind in inds
         da[ind] = val
     end
-    return val
+    return da
 end
 
 # TODO: Include BitArray indexing here.
@@ -260,8 +258,7 @@ end
 #' @param val::Any A value to be inserted into the specified entries of `da`.
 #' @param inds::AbstractVector A vector of indices of `da` to be modified.
 #'
-#' @returns val::T The value inserted into `da`, converted to the element
-#'          type of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -287,8 +284,7 @@ end
 #' @param val::Any A value to be inserted into the specified entries of `da`.
 #' @param inds::AbstractVector A vector of indices of `da` to be modified.
 #'
-#' @returns val::T The value inserted into `da`, converted to the element
-#'          type of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -301,5 +297,5 @@ function Base.setindex!{T}(da::AbstractDataArray{T},
     for ind in inds
         da[ind] = val
     end
-    return val
+    return da
 end

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -819,8 +819,7 @@ end
 #' @param ind::Real A real value specifying the index of the element
 #'        of `da` being modified.
 #'
-#' @returns val::NAtype The `NA` value that was assigned to an element
-#'          of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -830,7 +829,7 @@ function Base.setindex!(da::DataArray,
                         val::NAtype,
                         i::SingleIndex) # -> NAtype
 	da.na[i] = true
-    return NA
+    return da
 end
 
 #' @description
@@ -842,7 +841,7 @@ end
 #' @param ind::Real A real value specifying the index of the element
 #'        of `da` being modified.
 #'
-#' @returns val::Any The value that was assigned to an element of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -853,7 +852,7 @@ function Base.setindex!(da::DataArray,
                         ind::SingleIndex) # -> Any
 	da.data[ind] = val
 	da.na[ind] = false
-    return val
+    return da
 end
 
 #' @description
@@ -867,7 +866,7 @@ end
 #' @param inds::AbstractVector{Bool} A Boolean vector specifying for every
 #'        element of `da` whether it will be modified.
 #'
-#' @returns val::NAtype The NA value that was assigned to elements of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -877,7 +876,7 @@ function Base.setindex!(da::DataArray,
                         val::NAtype,
                         inds::AbstractVector{Bool}) # -> NAtype
     da.na[find(inds)] = true
-    return NA
+    return da
 end
 
 #' @description
@@ -889,7 +888,7 @@ end
 #' @param inds::AbstractVector A vector of indices of `da` to
 #'        be modified.
 #'
-#' @returns val::NAtype The NA value that was assigned to elements of `da`.
+#' @returns da::DataArray{T, N} The modified DataArray.
 #'
 #' @examples
 #'
@@ -899,7 +898,7 @@ function Base.setindex!(da::DataArray,
                         val::NAtype,
                         inds::AbstractVector) # -> NAtype
     da.na[inds] = true
-    return NA
+    return da
 end
 
 #' @description

--- a/src/datamatrix.jl
+++ b/src/datamatrix.jl
@@ -120,7 +120,7 @@ function Base.setindex!(dm::DataMatrix,
                         i::SingleIndex,
                         j::SingleIndex)
     dm.na[i, j] = true
-    return NA
+    return dm
 end
 
 # dm[SingleItemIndex, SingleItemIndex] = Single Item
@@ -130,7 +130,7 @@ function Base.setindex!(dm::DataMatrix,
                         j::SingleIndex)
     dm.data[i, j] = val
     dm.na[i, j] = false
-    return val
+    return dm
 end
 
 # dm[MultiItemIndex, SingleItemIndex] = NA
@@ -139,7 +139,7 @@ function Base.setindex!(dm::DataMatrix,
                         row_inds::MultiIndex,
                         j::SingleIndex)
     dm.na[row_inds, j] = true
-    return NA
+    return dm
 end
 
 # dm[MultiItemIndex, SingleItemIndex] = Multiple Items
@@ -149,7 +149,7 @@ function Base.setindex!{S, T}(dm::DataMatrix{S},
                               j::SingleIndex)
     dm.data[row_inds, j] = vals
     dm.na[row_inds, j] = false
-    return vals
+    return dm
 end
 
 # dm[MultiItemIndex, SingleItemIndex] = Single Item
@@ -159,7 +159,7 @@ function Base.setindex!(dm::DataMatrix,
                         j::SingleIndex)
     dm.data[row_inds, j] = val
     dm.na[row_inds, j] = false
-    return val
+    return dm
 end
 
 # dm[SingleItemIndex, MultiItemIndex] = NA
@@ -168,7 +168,7 @@ function Base.setindex!(dm::DataMatrix,
                         i::SingleIndex,
                         col_inds::MultiIndex)
     dm.na[i, col_inds] = true
-    return NA
+    return dm
 end
 
 # dm[SingleItemIndex, MultiItemIndex] = Multiple Items
@@ -178,7 +178,7 @@ function Base.setindex!{S, T}(dm::DataMatrix{S},
                               col_inds::MultiIndex)
     dm.data[i, col_inds] = vals
     dm.na[i, col_inds] = false
-    return vals
+    return dm
 end
 
 # dm[SingleItemIndex, MultiItemIndex] = Single Item
@@ -188,7 +188,7 @@ function Base.setindex!(dm::DataMatrix,
                         col_inds::MultiIndex)
     dm.data[i, col_inds] = val
     dm.na[i, col_inds] = false
-    return val
+    return dm
 end
 
 # dm[MultiItemIndex, MultiItemIndex] = NA
@@ -197,7 +197,7 @@ function Base.setindex!(dm::DataMatrix,
                         row_inds::MultiIndex,
                         col_inds::MultiIndex)
     dm.na[row_inds, col_inds] = true
-    return NA
+    return dm
 end
 
 # dm[MultiIndex, MultiIndex] = Multiple Items
@@ -207,7 +207,7 @@ function Base.setindex!{S, T}(dm::DataMatrix{S},
                               col_inds::MultiIndex)
     dm.data[row_inds, col_inds] = vals
     dm.na[row_inds, col_inds] = false
-    return vals
+    return dm
 end
 
 # dm[MultiItemIndex, MultiItemIndex] = Single Item
@@ -217,7 +217,7 @@ function Base.setindex!(dm::DataMatrix,
                         col_inds::MultiIndex)
     dm.data[row_inds, col_inds] = val
     dm.na[row_inds, col_inds] = false
-    return val
+    return dm
 end
 
 # Extract the matrix diagonal

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -562,7 +562,7 @@ end
 # R has the convention that if f is a factor then factor(f) drops unused levels
 function Base.setindex!(x::PooledDataArray, val::NAtype, ind::Real)
     x.refs[ind] = 0
-    return NA
+    return x
 end
 
 # x[SingleIndex] = Single Item
@@ -570,7 +570,7 @@ end
 function Base.setindex!{T,R}(x::PooledDataArray{T,R}, val::Any, ind::Real)
     val = convert(T, val)
     x.refs[ind] = getpoolidx(x, val)
-    return val
+    return x
 end
 
 # x[MultiIndex] = NA
@@ -588,11 +588,11 @@ end
 function Base.setindex!(x::PooledDataArray, val::NAtype, inds::AbstractVector{Bool})
     inds = find(inds)
     x.refs[inds] = 0
-    return NA
+    return x
 end
 function Base.setindex!(x::PooledDataArray, val::NAtype, inds::AbstractVector)
     x.refs[inds] = 0
-    return NA
+    return x
 end
 
 # pda[MultiIndex] = Multiple Values
@@ -607,19 +607,19 @@ function Base.setindex!(pda::PooledDataArray,
     for (val, ind) in zip(vals, inds)
         pda[ind] = val
     end
-    return vals
+    return pda
 end
 
 # pda[SingleItemIndex, SingleItemIndex] = NA
 function Base.setindex!{T,R}(pda::PooledDataMatrix{T,R}, val::NAtype, i::Real, j::Real)
     pda.refs[i, j] = zero(R)
-    return NA
+    return pda
 end
 # pda[SingleItemIndex, SingleItemIndex] = Single Item
 function Base.setindex!{T,R}(pda::PooledDataMatrix{T,R}, val::Any, i::Real, j::Real)
     val = convert(T, val)
     pda.refs[i, j] = getpoolidx(pda, val)
-    return val
+    return pda
 end
 
 ##############################################################################


### PR DESCRIPTION
For consistency with `Base`:

``` julia
v = [1:7]
r = setindex!(v, 4:6, 1:3)
r
7-element Array{Int64,1}:
 4
 5
 6
 4
 5
 6
 7
```

~~And I want to get rid of some unnecessary allocation in `DataFrames`' `setindex!` methods, but doing so would be inconsistent with `DataArrays` though consistent with `Base`.~~
