### PR TITLE
Cleaning up getindex for DataArray

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -716,8 +716,6 @@ function Base.getindex(d::DataArray, inds::MultiIndex)
         ix = inds[i]
         if !d.na[ix]
             res[i] = d.data[ix]
-        else
-            res[i] = NA # We could also change this in similar
         end
     end
     return res


### PR DESCRIPTION
The Number-specific getindex implementation failed on #undef elements in the DataArray data. For example,

``` Julia
x = DataArray(Integer, 5)
x[[1, 2]]
```

caused an

``` Julia
access to undefined reference
```

As fixing this would mean replicating the code from the more generic getindex methods, I suggest removing the more specific methods instead. Why where they there in the first place?

Furthermore, setting NA elements to NA explicitly after similar() is not required, as this is already done in similar().
