### PR TITLE
Respect order of input values in unique()

### DIFF
--- a/test/dataarray.jl
+++ b/test/dataarray.jl
@@ -41,6 +41,12 @@ module TestDataArray
     @test isequal(copy(x), x)
     @test isequal(copy!(y, x), x)
 
+    x = @data [1, -2, 1, NA, 4]
+    @assert isequal(unique(x), @data [1, -2, NA, 4])
+    @assert isequal(unique(reverse(x)), @data [4, NA, 1, -2])
+    @assert isequal(levels(x), @data [1, -2, 4])
+    @assert isequal(levels(reverse(x)), @data [4, 1, -2])
+
 	# Test vecbind
 	# a = [1:4]
 	# d = DataArray(a)

--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -27,6 +27,9 @@ module TestPDA
     @assert levels(setlevels!(copy(p), [1 => 111])) == [111, 8, 9]
     @assert levels(setlevels!(copy(p), [1 => 111, 8 => NA])) == [111, 9]
 
+    @assert isequal(unique(p), @pdata [9, 8, NA, 1])
+    @assert isequal(unique(reverse(p)), @pdata [1, NA, 8, 9])
+
     pp = PooledDataArray(Any[])
     @assert length(pp) == 0
     @assert length(levels(pp)) == 0


### PR DESCRIPTION
This is more consistent with the documentation of Base.unique().
Only NAs are always put at the end of the levels, for performance
reasons. Fixes the first part of #92.
