### PR TITLE
Update AbstractDataVector append! to allow appending to itself

### DIFF
--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -163,8 +163,9 @@ Base.deleteat!(pdv::PooledDataVector, inds) = (deleteat!(pdv.refs, inds); pdv)
 
 function Base.append!(da::AbstractDataVector, items::AbstractVector)
     oldn = length(da)
-    resize!(da, oldn+length(items))
-    da[oldn+1:end] = items
+    itn = length(items)
+    resize!(da, oldn+itn)
+    da[oldn+1:end] = items[1:itn]
     da
 end
 


### PR DESCRIPTION
Allow appending to itself. This also allows DataFrames to be appended to themselves. Previously calling append! with two references to the same DataVector would add NAs to the end, and this would corrupt DataFrames when calling append! with two references to the same DataFrame.
