### PR TITLE
Re-write {} as Any[] because {} is deprecated in 0.4

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -239,7 +239,7 @@ macro da_broadcast_vararg(func)
     end
 
     va = func.args[1].args[end]
-    defs = {}
+    defs = Any[]
     for n = 1:4, aa = 0:n-1
         def = deepcopy(func)
         rep = Any[symbol("A_$(i)") for i = 1:n]

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -16,7 +16,7 @@ end
 
 # Should be done with a proper N-dimensional Int array.
 function findna(dm::DataMatrix)
-    indices = {}
+    indices = Any[]
     n, p = size(dm)
     for i = 1:n
         for j = 1:p

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -283,9 +283,9 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
         # XXX It would be really nice to make this work with arbitrary
         # types, but doing so results in a bunch of method ambiguity
         # warnings
-        {
+        Any[
             begin
-                fns = {
+                fns = Any[
                     :(function $(vectorfunc)(a::DataArray, b::$t)
                         data = a.data
                         res = similar(data, $outtype)
@@ -303,7 +303,7 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                         end
                         res
                     end)
-                }
+                ]
                 if swappable
                     # For /, Array/Number is valid but not Number/Array
                     # All other operators should be swappable
@@ -312,7 +312,7 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                 Expr(:block, fns...)
             end
             for t in (:String, :Number)
-        }...
+        ]...
     ))
 end
 
@@ -320,7 +320,7 @@ end
 macro dataarray_binary_array(vectorfunc, scalarfunc, outtype)
     esc(Expr(:block,
         # DataArray with other array
-        {
+        Any[
             quote
                 function $(vectorfunc)(a::$atype, b::$btype)
                     data1 = $(atype == :DataArray || atype == :(DataArray{Bool}) ? :(a.data) : :a)
@@ -341,10 +341,10 @@ macro dataarray_binary_array(vectorfunc, scalarfunc, outtype)
                                            (:DataArray, :DataArray, :(a.na | b.na)),
                                            (:DataArray, :AbstractArray, :(copy(a.na))),
                                            (:AbstractArray, :DataArray, :(copy(b.na))))
-        }...,
+        ]...,
         # AbstractDataArray with other array
         # Definitinons with DataArray necessary to avoid ambiguity
-        {
+        Any[
             quote
                 function $(vectorfunc)(a::$atype, b::$btype)
                     res = similar($(asim ? :a : :b), $outtype, promote_shape(size(a), size(b)))
@@ -364,7 +364,7 @@ macro dataarray_binary_array(vectorfunc, scalarfunc, outtype)
                                          (true, :AbstractDataArray, :AbstractDataArray),
                                          (true, :AbstractDataArray, :AbstractArray),
                                          (false, :AbstractArray, :AbstractDataArray))
-        }...,
+        ]...,
     ))
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -13,7 +13,7 @@ module TestAbstractArray
     # isna with AbstractArray
     a = [1, 2, 3]
     @test isna(a) == falses(3)
-    a = {1, 2, NA, 3}
+    a = Any[1, 2, NA, 3]
     @test isna(a) == [false, false, true, false]
     for i = 1:length(a)
 	    @test isna(a, i) == isna(a)[i]

--- a/test/literals.jl
+++ b/test/literals.jl
@@ -124,7 +124,7 @@ module TestLiterals
                   PooledDataArray([1 0; 3 4],
                                   [false true; false false]))
     pdm = @pdata {1 NA;
-                3 4}
+                  3 4}
     @test isequal(pdm,
                   PooledDataArray({1 0; 3 4},
                                   [false true; false false]))
@@ -148,9 +148,9 @@ module TestLiterals
     mixed1 = @data ["x", 1, 1.23, NA]
     mixed2 = @data [NA, "x", 1, 1.23, NA]
 
-    @test isequal(mixed1, DataArray({"x", 1, 1.23, 0},
+    @test isequal(mixed1, DataArray(Any["x", 1, 1.23, 0],
                                     [false, false, false, true]))
-    @test isequal(mixed2, DataArray({NA, "x", 1, 1.23, 0},
+    @test isequal(mixed2, DataArray(Any[NA, "x", 1, 1.23, 0],
                                     [true, false, false, false, true]))
 
     x = 5.1
@@ -249,7 +249,7 @@ module TestLiterals
                              false false]))
 
     @test isequal(DataArrays.fixargs(:([1, 2, NA, x]).args, -1),
-                  ({1, 2, -1, :x}, {false, false, true, false}))
+                  (Any[1, 2, -1, :x], Any[false, false, true, false]))
 
     @test isequal(DataArrays.findstub_vector(:([1, 2, NA, x])), 1)
     @test isequal(DataArrays.findstub_vector(:([NA, NA, NA, x])), :x)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -119,12 +119,12 @@ myvar1m(x; skipna::Bool=false) = var(x; mean=1, skipna=skipna)
 for Areduc in (DataArray(rand(3, 4, 5, 6)),
                DataArray(rand(3, 4, 5, 6), rand(3, 4, 5, 6) .< 0.2))
     for skipna = (false, true)
-        for region in {
+        for region in Any[
             1, 2, 3, 4, 5, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
-            (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)}
+            (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)]
             # println("region = $region, skipna = $skipna")
 
-            outputs = {DataArray(fill(NaN, Base.reduced_dims(size(Areduc), region)))}
+            outputs = Any[DataArray(fill(NaN, Base.reduced_dims(size(Areduc), region)))]
             has_na = anyna(Areduc)
             if has_na && !skipna
                 # Should throw an error reducing to non-DataArray


### PR DESCRIPTION
This PR changes the use of braces in the `src` files and most of the `test` files.  There are several instances of braces in `test/literals.jl` that cannot be changes to `Any[]` successfully as they produce errors related to not being able to evaluate `zero(::Type{Any})`.
