### PR TITLE
Compute unary and some binary functions faster for PooledDataArray

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -262,6 +262,11 @@ macro dataarray_unary(f, intype, outtype, N...)
             end
             DataArray(res, copy(d.na))
         end
+        ## For pooled data, we only need to operate on .pool
+        function $(f){T<:$(intype),U}(pda::$(isempty(N) ? :(PooledDataArray{T,U}) : :(PooledDataArray{T,U,$(N[1])})))
+            PooledDataArray(RefArray(pda.refs), ($f)(pda.pool))
+        end
+        ## catchall:
         function $(f){T<:$(intype)}(adv::$(isempty(N) ? :(AbstractDataArray{T}) : :(AbstractDataArray{T,$(N[1])})))
             res = similar(adv, $(outtype))
             for i = 1:length(adv)
@@ -295,6 +300,11 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                             end
                         end
                         DataArray(res, copy(a.na))
+                    end),
+                    ## for PooledDataArrays, we only need to operate on .pool
+                    :(function $(vectorfunc)(a::PooledDataArray, b::$t)
+                        ## strange that I cannot say $(vectorfunc)(a.pool, b)
+                        PooledDataArray(RefArray(a.refs), [$(scalarfunc)(x, b) for x in a.pool])
                     end),
                     :(function $(vectorfunc)(a::AbstractDataArray, b::$t)
                         res = similar(a, $outtype)
@@ -670,6 +680,7 @@ end
 
 # Necessary to avoid ambiguity warnings
 Base.(:.^)(::MathConst{:e}, B::DataArray) = exp(B)
+Base.(:.^)(::MathConst{:e}, B::PooledDataArray) = exp(B)
 Base.(:.^)(::MathConst{:e}, B::AbstractDataArray) = exp(B)
 
 for f in (:(Base.(:+)), :(Base.(:.+)), :(Base.(:-)), :(Base.(:.-)),


### PR DESCRIPTION
This PR implements unary and some binary functions more efficiently for pooleddataarray, by only operating on the .pool rather than all entries of the matrix.   This is noticeable for very large arrays, e.g., 

using MFCC ## for warp(): this gives us quantized floating point values
x = warp(randn(100000,10)); ## a relatively slow operation, unfortunately
p = PooledDataArray(x)
@time exp(p);
