### PR TITLE
Fixed xtab and added docstrings

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -35,27 +35,43 @@ end
 
 gl(n::Integer, k::Integer) = gl(n, k, n*k)
 
-# A cross-tabulation type. Currently just a one-way table
-type xtab{T}
+#' @description
+#'
+#' A cross-tabulation type. Currently, this is just a one-way table.
+#'
+#' @field vals::Array{T} The values of the original data
+#' @field counts::Vector{Int} The counts corresponding to the values
+type Xtab{T}
     vals::Array{T}
     counts::Vector{Int}
 end
 
+#' @description
+#'
+#' Create a new cross-tabulation from the array `x`
+#' This is currently just for one-way tables.
+#'
+#' @param x::AbstractDataArray The AbstractDataArray with the data
+#'
+#' @returns out::Xtab The `Xtab` corresponding to `x`
 function xtab{T}(x::AbstractArray{T})
-    d = Dict{T, Int}()
-    for el in x
-        d[el] = get(d, el, 0) + 1
-    end
-    kk = sort(keys(d))
+    d = xtabs(x)
+    kk = sort(collect(keys(d)))
     cc = Array(Int, length(kk))
     for i in 1:length(kk)
         cc[i] = d[kk[i]]
     end
-    return xtab(kk, cc)
+    return Xtab(kk, cc)
 end
 
-# Another cross-tabulation function, this one leaves the result as a Dict
-# Again, this is currently just for one-way tables.
+#' @description
+#'
+#' A cross-tabulation function that returns the results as a Dict
+#' This is currently just for one-way tables.
+#'
+#' @param x::AbstractDataArray The AbstractDataArray with the data
+#'
+#' @returns out::Dict The values and their counts
 function xtabs{T}(x::AbstractArray{T})
     d = Dict{T, Int}()
     for el in x

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -4,5 +4,12 @@ module TestStats
 
     autocor(DataArray([1, 2, 3, 4, 5]))
 
-    @assert isequal(xtabs([1, 2, 2, 2, 3]), Dict([(2, 3), (3, 1), (1, 1)]))
+    xtab_data = [1, 2, 2, 2, 3]
+    @assert isequal(xtabs(xtab_data), Dict([(2, 3), (3, 1), (1, 1)]))
+
+    xt = xtab(xtab_data)
+    # Testing that the keys are correct and sorted
+    @assert xt.vals == [1, 2, 3]
+    # Testing that the counts are correct
+    @assert xt.counts == [1, 3, 1]
 end


### PR DESCRIPTION
This fixes the issue with `xtab`mentioned in #145 by using `sort(collect(keys))` instead of `sort(keys)`. Also, I added docstrings and did minor refactoring.

I'd be happy to help with docstrings for the rest of the package, but from what I understand now is not the best time for this, because you're working on major changes to the internals of the `DataArray`.
