### PR TITLE
Replace array with Base.convert

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -328,40 +328,6 @@ end
 
 #' @description
 #'
-#' Turn a DataArray into an Array. Raises an error if NA's are encountered.
-#'
-#' @param da::DataArray{T} DataArray that will be converted to an Array.
-#'
-#' @returns a::Array{T} Array containing values of `da`.
-#'
-#' @examples
-#'
-#' dv = @data [1, 2, 3, 4]
-#' v = convert(Vector, dv)
-#'
-#' dm = @data [1 2; 3 4]
-#' m = convert(Matrix, dm)
-function array{T}(da::DataArray{T}) # -> Array{T}
-    Base.depwarn(
-        """
-        array(da::DataArray{T}) is deprecated.
-        Use convert(Array, da).
-        """,
-        :array
-    )
-    res = Array(T, size(da))
-    for i in 1:length(da)
-        if da.na[i]
-            throw(NAException())
-        else
-            res[i] = da.data[i]
-        end
-    end
-    return res
-end
-
-#' @description
-#'
 #' Convert a DataArray{T} to an Array{S}. Throws an `NAException`
 #' if the input contains `NA` values that prohibit conversion.
 #'
@@ -401,43 +367,6 @@ end
 
 function Base.convert{T, N}(::Type{Array}, da::DataArray{T, N})
     return convert(Array{T, N}, da)
-end
-
-#' @description
-#'
-#' Turn a DataArray into an Array. Replace any NA's with the value
-#' of second argument, `replacement`.
-#'
-#' @param da::DataArray{T} DataArray that will be converted to an Array.
-#' @param replacement::T Value that will replace NA's in `da`.
-#'
-#' @returns a::Array{T} Array containing values of `da` plus replacements.
-#'
-#' @examples
-#'
-#' dv = @data [1, 2, NA, 4]
-#' v = convert(Vector, dv, 3)
-#'
-#' dm = @data [1 2; NA 4]
-#' m = convert(Matrix, dm, 3)
-function array{T}(da::DataArray{T}, replacement::Any) # -> Array{T}
-    Base.depwarn(
-        """
-        array(da::DataArray{T}, replacement::Any) is deprecated.
-        Use convert(Array, da, replacement) instead.
-        """,
-        :array
-    )
-    res = Array(T, size(da))
-    replacementT = convert(T, replacement)
-    for i in 1:length(da)
-        if da.na[i]
-            res[i] = replacementT
-        else
-            res[i] = da.data[i]
-        end
-    end
-    return res
 end
 
 function Base.convert{S, T, N}(

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -337,11 +337,18 @@ end
 #' @examples
 #'
 #' dv = @data [1, 2, 3, 4]
-#' v = array(dv)
+#' v = convert(Vector, dv)
 #'
 #' dm = @data [1 2; 3 4]
-#' m = array(dm)
+#' m = convert(Matrix, dm)
 function array{T}(da::DataArray{T}) # -> Array{T}
+    Base.depwarn(
+        """
+        array(da::DataArray{T}) is deprecated.
+        Use convert(Array, da).
+        """,
+        :array
+    )
     res = Array(T, size(da))
     for i in 1:length(da)
         if da.na[i]
@@ -351,6 +358,49 @@ function array{T}(da::DataArray{T}) # -> Array{T}
         end
     end
     return res
+end
+
+#' @description
+#'
+#' Convert a DataArray{T} to an Array{S}. Throws an `NAException`
+#' if the input contains `NA` values that prohibit conversion.
+#'
+#' @param da::DataArray{T} The DataArray that will be converted.
+#'
+#' @returns a::Array{S} The (possibly type-converted) elements of
+#'         `da` if none were `NA`.
+#'
+#' @examples
+#'
+#' da = @data [1 2; 3 NA]
+#' a = convert(Array{Float64}, da)
+#'
+#' da = @data [1 2; 3 4]
+#' a = convert(Array{Float64}, da)
+function Base.convert{S, T, N}(::Type{Array{S, N}},
+                               x::DataArray{T, N}) # -> Array{S, N}
+    if anyna(x)
+        err = "Cannot convert DataArray with NA's to desired type"
+        throw(NAException(err))
+    else
+        return convert(Array{S, N}, x.data)
+    end
+end
+
+function Base.convert{S, T, N}(::Type{Array{S}}, da::DataArray{T, N})
+    return convert(Array{S, N}, da)
+end
+
+function Base.convert{T}(::Type{Vector}, dv::DataVector{T})
+    return convert(Array{T, 1}, dv)
+end
+
+function Base.convert{T}(::Type{Matrix}, dm::DataMatrix{T})
+    return convert(Array{T, 2}, dm)
+end
+
+function Base.convert{T, N}(::Type{Array}, da::DataArray{T, N})
+    return convert(Array{T, N}, da)
 end
 
 #' @description
@@ -366,15 +416,23 @@ end
 #' @examples
 #'
 #' dv = @data [1, 2, NA, 4]
-#' v = array(dv, 3)
+#' v = convert(Vector, dv, 3)
 #'
 #' dm = @data [1 2; NA 4]
-#' m = array(dm, 3)
-function array{T}(da::DataArray{T}, replacement::T) # -> Array{T}
+#' m = convert(Matrix, dm, 3)
+function array{T}(da::DataArray{T}, replacement::Any) # -> Array{T}
+    Base.depwarn(
+        """
+        array(da::DataArray{T}, replacement::Any) is deprecated.
+        Use convert(Array, da, replacement) instead.
+        """,
+        :array
+    )
     res = Array(T, size(da))
+    replacementT = convert(T, replacement)
     for i in 1:length(da)
         if da.na[i]
-            res[i] = replacement
+            res[i] = replacementT
         else
             res[i] = da.data[i]
         end
@@ -382,26 +440,33 @@ function array{T}(da::DataArray{T}, replacement::T) # -> Array{T}
     return res
 end
 
-#' @description
-#'
-#' Turn a DataArray into an Array. Replace any NA's with the value
-#' of second argument, `replacement`.
-#'
-#' @param da::DataArray{T} DataArray that will be converted to an Array.
-#' @param replacement::Any Value that will replace NA's in `da`.
-#'        Converted to the `eltype`, `T`, of `da`.
-#'
-#' @returns a::Array{T} Array containing values of `da` plus replacements.
-#'
-#' @examples
-#'
-#' dv = @data [1, 2, NA, 4]
-#' v = array(dv, 3)
-#'
-#' dm = @data [1 2; NA 4]
-#' m = array(dm, 3)
-function array{T}(da::DataArray{T}, replacement::Any) # -> Array{T}
-    return array(da, convert(T, replacement))
+function Base.convert{S, T, N}(
+    ::Type{Array{S, N}},
+    da::DataArray{T, N},
+    replacement::Any
+) # -> Array{S, N}
+    replacementS = convert(S, replacement)
+    res = Array(S, size(da))
+    for i in 1:length(da)
+        if da.na[i]
+            res[i] = replacementS
+        else
+            res[i] = da.data[i]
+        end
+    end
+    return res
+end
+
+function Base.convert{T}(::Type{Vector}, dv::DataVector{T}, replacement::Any)
+    return convert(Array{T, 1}, dv, replacement)
+end
+
+function Base.convert{T}(::Type{Matrix}, dm::DataMatrix{T}, replacement::Any)
+    return convert(Array{T, 2}, dm, replacement)
+end
+
+function Base.convert{T, N}(::Type{Array}, da::DataArray{T, N}, replacement::Any)
+    return convert(Array{T, N}, da, replacement)
 end
 
 #' @description
@@ -536,37 +601,6 @@ end
 # promote_rule{S, T}(::Type{AbstractDataArray{S}},
 #                    ::Type{T}) = promote_rule(S, T)
 # promote_rule{T}(::Type{AbstractDataArray{T}}, ::Type{T}) = T
-
-#' @description
-#'
-#' Convert a DataArray{T} to an Array{S}. Throws an `NAException`
-#' if the input contains `NA` values that prohibit conversion.
-#'
-#' @param da::DataArray{T} The DataArray that will be converted.
-#'
-#' @returns a::Array{S} The (possibly type-converted) elements of
-#'         `da` if none were `NA`.
-#'
-#' @examples
-#'
-#' da = @data [1 2; 3 NA]
-#' a = convert(Array{Float64}, da)
-#'
-#' da = @data [1 2; 3 4]
-#' a = convert(Array{Float64}, da)
-function Base.convert{S, T, N}(::Type{Array{S, N}},
-                               x::DataArray{T, N}) # -> Array{S, N}
-    if anyna(x)
-        err = "Cannot convert DataArray with NA's to desired type"
-        throw(NAException(err))
-    else
-        return convert(Array{S, N}, x.data)
-    end
-end
-Base.convert{S,T,N}(::Type{Array{S}}, x::DataArray{T,N}) =
-    convert(Array{S,N}, x)
-Base.convert{T,N}(::Type{Array}, x::DataArray{T,N}) =
-    convert(Array{T,N}, x)
 
 #' @description
 #'

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,3 +2,115 @@
 #       when the deprecation is removed
 import Base.@deprecate
 @deprecate (/)(x::Union(NAtype,Number),A::AbstractDataArray)    x ./ A
+
+#' @description
+#'
+#' Turn a DataArray into an Array. Raises an error if NA's are encountered.
+#'
+#' @param da::DataArray{T} DataArray that will be converted to an Array.
+#'
+#' @returns a::Array{T} Array containing values of `da`.
+#'
+#' @examples
+#'
+#' dv = @data [1, 2, 3, 4]
+#' v = convert(Vector, dv)
+#'
+#' dm = @data [1 2; 3 4]
+#' m = convert(Matrix, dm)
+function array{T}(da::DataArray{T}) # -> Array{T}
+    Base.depwarn(
+        """
+        array(da::DataArray{T}) is deprecated.
+        Use convert(Array, da).
+        """,
+        :array
+    )
+    res = Array(T, size(da))
+    for i in 1:length(da)
+        if da.na[i]
+            throw(NAException())
+        else
+            res[i] = da.data[i]
+        end
+    end
+    return res
+end
+
+#' @description
+#'
+#' Turn a DataArray into an Array. Replace any NA's with the value
+#' of second argument, `replacement`.
+#'
+#' @param da::DataArray{T} DataArray that will be converted to an Array.
+#' @param replacement::T Value that will replace NA's in `da`.
+#'
+#' @returns a::Array{T} Array containing values of `da` plus replacements.
+#'
+#' @examples
+#'
+#' dv = @data [1, 2, NA, 4]
+#' v = convert(Vector, dv, 3)
+#'
+#' dm = @data [1 2; NA 4]
+#' m = convert(Matrix, dm, 3)
+function array{T}(da::DataArray{T}, replacement::Any) # -> Array{T}
+    Base.depwarn(
+        """
+        array(da::DataArray{T}, replacement::Any) is deprecated.
+        Use convert(Array, da, replacement) instead.
+        """,
+        :array
+    )
+    res = Array(T, size(da))
+    replacementT = convert(T, replacement)
+    for i in 1:length(da)
+        if da.na[i]
+            res[i] = replacementT
+        else
+            res[i] = da.data[i]
+        end
+    end
+    return res
+end
+
+# Turn a PooledDataArray into an Array. Fail on NA
+function array{T, R}(da::PooledDataArray{T, R})
+    Base.depwarn(
+        """
+        array(pda::PooledDataArray{T, R}) is deprecated.
+        Use convert(Array, pda) instead.
+        """,
+        :array
+    )
+    n = length(da)
+    res = Array(T, size(da))
+    for i in 1:n
+        if da.refs[i] == zero(R)
+            throw(NAException())
+        else
+            res[i] = da.pool[da.refs[i]]
+        end
+    end
+    return res
+end
+
+function array{T, R}(da::PooledDataArray{T, R}, replacement::T)
+    Base.depwarn(
+        """
+        array(pda::PooledDataArray{T, R}, replacement::T) is deprecated.
+        Use convert(Array, pda, replacement) instead.
+        """,
+        :array
+    )
+    n = length(da)
+    res = Array(T, size(da))
+    for i in 1:n
+        if da.refs[i] == zero(R)
+            res[i] = replacement
+        else
+            res[i] = da.pool[da.refs[i]]
+        end
+    end
+    return res
+end

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -763,27 +763,6 @@ Base.convert{T,R<:Integer,N}(::Type{DataArray}, pda::PooledDataArray{T,R,N}) =
 
 pdata(a::AbstractArray) = convert(PooledDataArray, a)
 
-# Turn a PooledDataArray into an Array. Fail on NA
-function array{T, R}(da::PooledDataArray{T, R})
-    Base.depwarn(
-        """
-        array(pda::PooledDataArray{T, R}) is deprecated.
-        Use convert(Array, pda) instead.
-        """,
-        :array
-    )
-    n = length(da)
-    res = Array(T, size(da))
-    for i in 1:n
-        if da.refs[i] == zero(R)
-            throw(NAException())
-        else
-            res[i] = da.pool[da.refs[i]]
-        end
-    end
-    return res
-end
-
 function Base.convert{S, T, R, N}(
     ::Type{Array{S, N}},
     pda::PooledDataArray{T, R, N}
@@ -809,26 +788,6 @@ end
 
 function Base.convert{T, R, N}(::Type{Array}, pda::PooledDataArray{T, R, N})
     return convert(Array{T, N}, pda)
-end
-
-function array{T, R}(da::PooledDataArray{T, R}, replacement::T)
-    Base.depwarn(
-        """
-        array(pda::PooledDataArray{T, R}, replacement::T) is deprecated.
-        Use convert(Array, pda, replacement) instead.
-        """,
-        :array
-    )
-    n = length(da)
-    res = Array(T, size(da))
-    for i in 1:n
-        if da.refs[i] == zero(R)
-            res[i] = replacement
-        else
-            res[i] = da.pool[da.refs[i]]
-        end
-    end
-    return res
 end
 
 function Base.convert{S, T, R, N}(

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -459,7 +459,7 @@ end
 ##
 ##############################################################################
 
-Base.find(pdv::PooledDataVector{Bool}) = find(array(pdv, false))
+Base.find(pdv::PooledDataVector{Bool}) = find(convert(Vector{Bool}, pdv, false))
 
 ##############################################################################
 ##
@@ -765,6 +765,13 @@ pdata(a::AbstractArray) = convert(PooledDataArray, a)
 
 # Turn a PooledDataArray into an Array. Fail on NA
 function array{T, R}(da::PooledDataArray{T, R})
+    Base.depwarn(
+        """
+        array(pda::PooledDataArray{T, R}) is deprecated.
+        Use convert(Array, pda) instead.
+        """,
+        :array
+    )
     n = length(da)
     res = Array(T, size(da))
     for i in 1:n
@@ -777,7 +784,41 @@ function array{T, R}(da::PooledDataArray{T, R})
     return res
 end
 
+function Base.convert{S, T, R, N}(
+    ::Type{Array{S, N}},
+    pda::PooledDataArray{T, R, N}
+)
+    res = Array(S, size(pda))
+    for i in 1:length(pda)
+        if pda.refs[i] == zero(R)
+            throw(NAException())
+        else
+            res[i] = pda.pool[pda.refs[i]]
+        end
+    end
+    return res
+end
+
+function Base.convert{T, R}(::Type{Vector}, pdv::PooledDataVector{T, R})
+    return convert(Array{T, 1}, pdv)
+end
+
+function Base.convert{T, R}(::Type{Matrix}, pdm::PooledDataMatrix{T, R})
+    return convert(Array{T, 2}, pdm)
+end
+
+function Base.convert{T, R, N}(::Type{Array}, pda::PooledDataArray{T, R, N})
+    return convert(Array{T, N}, pda)
+end
+
 function array{T, R}(da::PooledDataArray{T, R}, replacement::T)
+    Base.depwarn(
+        """
+        array(pda::PooledDataArray{T, R}, replacement::T) is deprecated.
+        Use convert(Array, pda, replacement) instead.
+        """,
+        :array
+    )
     n = length(da)
     res = Array(T, size(da))
     for i in 1:n
@@ -788,6 +829,35 @@ function array{T, R}(da::PooledDataArray{T, R}, replacement::T)
         end
     end
     return res
+end
+
+function Base.convert{S, T, R, N}(
+    ::Type{Array{S, N}},
+    pda::PooledDataArray{T, R, N},
+    replacement::Any
+)
+    res = Array(S, size(pda))
+    replacementS = convert(S, replacement)
+    for i in 1:length(pda)
+        if pda.refs[i] == zero(R)
+            res[i] = replacementS
+        else
+            res[i] = pda.pool[pda.refs[i]]
+        end
+    end
+    return res
+end
+
+function Base.convert{T, R}(::Type{Vector}, pdv::PooledDataVector{T, R}, replacement::Any)
+    return convert(Array{T, 1}, pdv, replacement)
+end
+
+function Base.convert{T, R}(::Type{Matrix}, pdm::PooledDataMatrix{T, R}, replacement::Any)
+    return convert(Array{T, 2}, pdm, replacement)
+end
+
+function Base.convert{T, R, N}(::Type{Array}, pda::PooledDataArray{T, R, N}, replacement::Any)
+    return convert(Array{T, N}, pda, replacement)
 end
 
 function dropna{T}(pdv::PooledDataVector{T})

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,24 +1,22 @@
 module TestConversions
-	using Base.Test
-	using DataArrays
+    using Base.Test
+    using DataArrays
 
-	@assert isequal(@data([1, 2, NA]),
-		            convert(DataArray, @pdata([1, 2, NA])))
+    @assert isequal(@data([1, 2, NA]),
+                    convert(DataArray, @pdata([1, 2, NA])))
 
-	# Test vector() and matrix() conversion tools
-	dv = @data ones(5)
-	@assert isa(array(dv), Vector{Float64})
-	@assert isa(convert(Vector{Float64}, dv), Vector{Float64})
-	dv[1] = NA
-	# Should raise errors:
-	# vector(dv)
-	# convert(Vector{Float64}, dv)
+    # Test vector() and matrix() conversion tools
+    dv = @data ones(5)
+    @assert isa(convert(Vector{Float64}, dv), Vector{Float64})
+    dv[1] = NA
+    # Should raise errors:
+    # vector(dv)
+    # convert(Vector{Float64}, dv)
 
-	dm = @data ones(3, 3)
-	@assert isa(array(dm), Matrix{Float64})
-	@assert isa(convert(Matrix{Float64}, dm), Matrix{Float64})
-	dm[1, 1] = NA
-	# Should raise errors:
-	# matrix(dm)
-	# convert(Matrix{Float64}, dm)
+    dm = @data ones(3, 3)
+    @assert isa(convert(Matrix{Float64}, dm), Matrix{Float64})
+    dm[1, 1] = NA
+    # Should raise errors:
+    # matrix(dm)
+    # convert(Matrix{Float64}, dm)
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -18,6 +18,7 @@ module TestData
     dvflt = @data [1.0, 2, NA, 4]
     dvstr = @data ["one", "two", NA, "four"]
     dvdict = DataArray(Dict, 4) # for issue #199
+    dvany = convert(DataArray{Any, 1}, dvint)
 
     @assert isa(dvint, DataVector{Int})
     @assert isa(dvint2, DataVector{Int})
@@ -95,6 +96,7 @@ module TestData
     #test_group("DataVector to something else")
     @assert all(dropna(dvint) .== [1, 2, 4])
     @assert all(convert(Vector, dvint, 0) .== [1, 2, 0, 4])
+    @assert all(convert(Vector, dvany, 0) .== [1, 2, 0, 4])
     utf8three = convert(UTF8String, "three")
     asciithree = convert(ASCIIString, "three")
     @assert all(convert(Vector, dvstr, utf8three) .== ["one", "two", "three", "four"])

--- a/test/data.jl
+++ b/test/data.jl
@@ -24,7 +24,7 @@ module TestData
     @assert isa(dvint3, DataVector{Int})
     @assert isa(dvflt, DataVector{Float64})
     @assert isa(dvstr, DataVector{ASCIIString})
-    # @test throws_exception(DataArray([5:8], falses(2)), Exception) 
+    # @test throws_exception(DataArray([5:8], falses(2)), Exception)
 
     #test_group("PooledDataVector creation")
     pdvstr = @pdata ["one", "one", "two", "two", NA, "one", "one"]
@@ -97,8 +97,8 @@ module TestData
     @assert all(array(dvint, 0) .== [1, 2, 0, 4])
     utf8three = convert(UTF8String, "three")
     asciithree = convert(ASCIIString, "three")
-    @assert all(array(dvstr, utf8three) .== ["one", "two", "three", "four"])
-    @assert all(array(dvstr, asciithree) .== ["one", "two", "three", "four"])
+    @assert all(convert(dvstr, utf8three) .== ["one", "two", "three", "four"])
+    @assert all(convert(dvstr, asciithree) .== ["one", "two", "three", "four"])
     @assert all(convert(Vector{Int}, dvint2) .== 5:8)
     @assert all([i + 1 for i in dvint2] .== 6:9)
     @assert all([length(x)::Int for x in dvstr] == [3, 3, 1, 4])
@@ -157,7 +157,7 @@ module TestData
     ret = (pdvstr2[[true, false, true, false]] = "three")
     @assert ret == "three"
     @assert pdvstr2[1] == "three"
-    ret = (pdvstr2[[false, true, false, true]] = ["four", "five"]) 
+    ret = (pdvstr2[[false, true, false, true]] = ["four", "five"])
     @assert isequal(ret, ["four", "five"])
     @assert isequal(pdvstr2[3:4], (@data ["three", "five"]))
     pdvstr2 = @pdata ["one", "one", "two", "two"]

--- a/test/data.jl
+++ b/test/data.jl
@@ -94,31 +94,31 @@ module TestData
 
     #test_group("DataVector to something else")
     @assert all(dropna(dvint) .== [1, 2, 4])
-    @assert all(array(dvint, 0) .== [1, 2, 0, 4])
+    @assert all(convert(Vector, dvint, 0) .== [1, 2, 0, 4])
     utf8three = convert(UTF8String, "three")
     asciithree = convert(ASCIIString, "three")
-    @assert all(convert(dvstr, utf8three) .== ["one", "two", "three", "four"])
-    @assert all(convert(dvstr, asciithree) .== ["one", "two", "three", "four"])
-    @assert all(convert(Vector{Int}, dvint2) .== 5:8)
-    @assert all([i + 1 for i in dvint2] .== 6:9)
+    @assert all(convert(Vector, dvstr, utf8three) .== ["one", "two", "three", "four"])
+    @assert all(convert(Vector, dvstr, asciithree) .== ["one", "two", "three", "four"])
+    @assert all(convert(Vector{Int}, dvint2) .== [5:8])
+    @assert all([i + 1 for i in dvint2] .== [6:9])
     @assert all([length(x)::Int for x in dvstr] == [3, 3, 1, 4])
     @assert repr(dvint) == "[1,2,NA,4]"
 
     #test_group("PooledDataVector to something else")
     @assert all(dropna(pdvstr) .== ["one", "one", "two", "two", "one", "one"])
-    @assert all(array(pdvstr, "nine") .== ["one", "one", "two", "two", "nine", "one", "one"])
+    @assert all(convert(Vector, pdvstr, "nine") .== ["one", "one", "two", "two", "nine", "one", "one"])
     @assert all([length(i)::Int for i in pdvstr] .== [3, 3, 3, 3, 1, 3, 3])
     @assert string(pdvstr[1:3]) == "[one, one, two]"
 
     #test_group("DataVector Filter and Replace")
     @assert isequal(dropna(dvint), [1, 2, 4])
-    @assert isequal(array(dvint, 7), [1, 2, 7, 4])
+    @assert isequal(convert(Vector, dvint, 7), [1, 2, 7, 4])
     @assert sum(dropna(dvint)) == 7
-    @assert sum(array(dvint, 7)) == 14
+    @assert sum(convert(Vector, dvint, 7)) == 14
 
     #test_group("PooledDataVector Filter and Replace")
     @assert reduce(string, "", dropna(pdvstr)) == "oneonetwotwooneone"
-    @assert reduce(string, "", array(pdvstr, "!")) == "oneonetwotwo!oneone"
+    @assert reduce(string, "", convert(Vector, pdvstr, "!")) == "oneonetwotwo!oneone"
 
     #test_group("DataVector assignment")
     assigntest = @data [1, 2, NA, 4]

--- a/test/datamatrix.jl
+++ b/test/datamatrix.jl
@@ -1,129 +1,129 @@
 module TestDataMatrix
-	using Base.Test
-	using DataArrays
+    using Base.Test
+    using DataArrays
 
-	a = @data [1.0, 2.0, 3.0]
-	v_a = [1.0, 2.0, 3.0]
+    a = @data [1.0, 2.0, 3.0]
+    v_a = [1.0, 2.0, 3.0]
 
-	b = @data eye(3, 3)
-	m_b = eye(3, 3)
+    b = @data eye(3, 3)
+    m_b = eye(3, 3)
 
-	#
-	# Transposes
-	#
+    #
+    # Transposes
+    #
 
-	@assert all(a' .== v_a')
-	@assert all(a'' .== v_a'')
-	@assert all(b' .== m_b')
-	@assert all(b'' .== m_b'')
+    @assert all(a' .== v_a')
+    @assert all(a'' .== v_a'')
+    @assert all(b' .== m_b')
+    @assert all(b'' .== m_b'')
 
-	#
-	# DataVector * DataMatrix
-	#
+    #
+    # DataVector * DataMatrix
+    #
 
-	# TODO: Get indexing for b[1, :] to work
-	# @assert all(a * b[1, :] .== v_a * m_b[1, :])
+    # TODO: Get indexing for b[1, :] to work
+    # @assert all(a * b[1, :] .== v_a * m_b[1, :])
 
-	#
-	# DataMatrix * DataVector
-	#
+    #
+    # DataMatrix * DataVector
+    #
 
-	@assert all(b * a .== m_b * v_a)
-	@assert all(array(b * a) .== m_b * v_a)
+    @assert all(b * a .== m_b * v_a)
+    @assert all(convert(Array, b * a) .== m_b * v_a)
 
-	#
-	# DataMatrix * DataMatrix
-	#
+    #
+    # DataMatrix * DataMatrix
+    #
 
-	@assert all(b * b .== m_b * m_b)
+    @assert all(b * b .== m_b * m_b)
 
-	#
-	# DataVector * DataMatrix w/ NA's
-	#
+    #
+    # DataVector * DataMatrix w/ NA's
+    #
 
-	b[1, 1] = NA
-	res = a * b[1, :]
-	@assert all(isna(res[:, 1]))
-	@assert all(!isna(res[:, 2]))
-	@assert all(!isna(res[:, 3]))
-	res = a * b[2, :]
-	@assert all(!isna(res))
+    b[1, 1] = NA
+    res = a * b[1, :]
+    @assert all(isna(res[:, 1]))
+    @assert all(!isna(res[:, 2]))
+    @assert all(!isna(res[:, 3]))
+    res = a * b[2, :]
+    @assert all(!isna(res))
 
-	#
-	# DataMatrix w NA's * DataVector
-	#
+    #
+    # DataMatrix w NA's * DataVector
+    #
 
-	res = b * a
-	@assert isna(res[1])
-	@assert !isna(res[2])
-	@assert !isna(res[3])
+    res = b * a
+    @assert isna(res[1])
+    @assert !isna(res[2])
+    @assert !isna(res[3])
 
-	#
-	# DataMatrix * DataMatrix
-	#
+    #
+    # DataMatrix * DataMatrix
+    #
 
-	res = b * b
-	# 3x3 Float64 DataMatrix:
-	#  NA   NA   NA
-	#  NA  1.0  0.0
-	#  NA  0.0  1.0
-	@assert isna(res[1, 1])
-	@assert isna(res[1, 2])
-	@assert isna(res[1, 3])
-	@assert isna(res[2, 1])
-	@assert !isna(res[2, 2])
-	@assert !isna(res[2, 3])
-	@assert isna(res[3, 1])
-	@assert !isna(res[3, 2])
-	@assert !isna(res[3, 3])
+    res = b * b
+    # 3x3 Float64 DataMatrix:
+    #  NA   NA   NA
+    #  NA  1.0  0.0
+    #  NA  0.0  1.0
+    @assert isna(res[1, 1])
+    @assert isna(res[1, 2])
+    @assert isna(res[1, 3])
+    @assert isna(res[2, 1])
+    @assert !isna(res[2, 2])
+    @assert !isna(res[2, 3])
+    @assert isna(res[3, 1])
+    @assert !isna(res[3, 2])
+    @assert !isna(res[3, 3])
 
-	res = b * @data eye(3)
-	# 3x3 Float64 DataMatrix:
-	#   NA   NA   NA
-	#  0.0  1.0  0.0
-	#  0.0  0.0  1.0
-	@assert isna(res[1, 1])
-	@assert isna(res[1, 2])
-	@assert isna(res[1, 3])
-	@assert !isna(res[2, 1])
-	@assert !isna(res[2, 2])
-	@assert !isna(res[2, 3])
-	@assert !isna(res[3, 1])
-	@assert !isna(res[3, 2])
-	@assert !isna(res[3, 3])
+    res = b * @data eye(3)
+    # 3x3 Float64 DataMatrix:
+    #   NA   NA   NA
+    #  0.0  1.0  0.0
+    #  0.0  0.0  1.0
+    @assert isna(res[1, 1])
+    @assert isna(res[1, 2])
+    @assert isna(res[1, 3])
+    @assert !isna(res[2, 1])
+    @assert !isna(res[2, 2])
+    @assert !isna(res[2, 3])
+    @assert !isna(res[3, 1])
+    @assert !isna(res[3, 2])
+    @assert !isna(res[3, 3])
 
-	res = (@data eye(3)) * b
-	# julia> dataeye(3) * b
-	# 3x3 Float64 DataMatrix:
-	#  NA  0.0  0.0
-	#  NA  1.0  0.0
-	#  NA  0.0  1.0
-	@assert isna(res[1, 1])
-	@assert !isna(res[1, 2])
-	@assert !isna(res[1, 3])
-	@assert isna(res[2, 1])
-	@assert !isna(res[2, 2])
-	@assert !isna(res[2, 3])
-	@assert isna(res[3, 1])
-	@assert !isna(res[3, 2])
-	@assert !isna(res[3, 3])
+    res = (@data eye(3)) * b
+    # julia> dataeye(3) * b
+    # 3x3 Float64 DataMatrix:
+    #  NA  0.0  0.0
+    #  NA  1.0  0.0
+    #  NA  0.0  1.0
+    @assert isna(res[1, 1])
+    @assert !isna(res[1, 2])
+    @assert !isna(res[1, 3])
+    @assert isna(res[2, 1])
+    @assert !isna(res[2, 2])
+    @assert !isna(res[2, 3])
+    @assert isna(res[3, 1])
+    @assert !isna(res[3, 2])
+    @assert !isna(res[3, 3])
 
-	# Test row operations
-	dm = @data eye(6, 2)
-	# rowmeans(dm)
+    # Test row operations
+    dm = @data eye(6, 2)
+    # rowmeans(dm)
 
-	# Test column operations
-	dm = @data eye(6, 2)
-	# colmeans(dm)
+    # Test column operations
+    dm = @data eye(6, 2)
+    # colmeans(dm)
 
-	# Test linear algebra
-	du, dd, dv = svd((@data eye(3, 3)))
-	u, d, v = svd(eye(3, 3))
-	@assert all(du .== u)
-	@assert all(dd .== d)
-	@assert all(dv .== v)
+    # Test linear algebra
+    du, dd, dv = svd((@data eye(3, 3)))
+    u, d, v = svd(eye(3, 3))
+    @assert all(du .== u)
+    @assert all(dd .== d)
+    @assert all(dv .== v)
 
-	# Test elementary functions
-	dm = -(@data eye(5, 5))
-	@assert all(abs(dm) .== eye(5, 5))
+    # Test elementary functions
+    dm = -(@data eye(5, 5))
+    @assert all(abs(dm) .== eye(5, 5))
 end

--- a/test/newtests/dataarray.jl
+++ b/test/newtests/dataarray.jl
@@ -2,332 +2,332 @@
 # TODO: Pull in existing tests into this file
 # TODO: Rename to TestDataArray
 module TestDataArrays
-	using DataArrays, Base.Test
-
-	# DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
-	DataArray([1, 2], falses(2))
-	DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2))
-	DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-
-	DataArray([1, 2], trues(2))
-	DataArray(repeat([1, 2], outer = [1, 2]), trues(2, 2))
-	DataArray(repeat([1, 2], outer = [1, 2, 2]), trues(2, 2, 2))
-
-	DataArray(['a', 'b'], falses(2))
-	DataArray(repeat(['a', 'b'], outer = [1, 2]), falses(2, 2))
-	DataArray(repeat(['a', 'b'], outer = [1, 2, 2]), falses(2, 2, 2))
-
-	DataArray(['a', 'b'], trues(2))
-	DataArray(repeat(['a', 'b'], outer = [1, 2]), trues(2, 2))
-	DataArray(repeat(['a', 'b'], outer = [1, 2, 2]), trues(2, 2, 2))
-
-	# DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
-	DataArray([1, 2])
-	DataArray(repeat([1, 2], outer = [1, 2]))
-	DataArray(repeat([1, 2], outer = [1, 2, 2]))
-
-	DataArray(['a', 'b'])
-	DataArray(repeat(['a', 'b'], outer = [1, 2]))
-	DataArray(repeat(['a', 'b'], outer = [1, 2, 2]))
-
-	# DataArray(d::Array, m::Array{Bool})
-	DataArray([1, 2], [false, false])
-	DataArray(['a', 'b'], [false, false])
-
-	DataArray([1, 2], [true, true])
-	DataArray(['a', 'b'], [true, true])
-
-	# DataArray(d::BitArray, m::BitArray = falses(size(d)))
-	convert(DataArray, falses(2))
-	convert(DataArray, trues(2))
-
-	# DataArray(d::BitArray, m::BitArray = falses(size(d)))
-	convert(DataArray, falses(2))
-	convert(DataArray, trues(2))
-
-	# DataArray(d::Ranges, m::BitArray = falses(length(d)))
-	convert(DataArray, 1:2)
-	convert(DataArray, 1:2)
-
-	# DataArray(t::Type, dims::Integer...)
-	DataArray(Float64, 2)
-	DataArray(Float64, 2, 2)
-	DataArray(Float64, 2, 2, 2)
-
-	DataArray(Char, 2)
-	DataArray(Char, 2, 2)
-	DataArray(Char, 2, 2, 2)
-
-	# DataArray{N}(t::Type, dims::NTuple{N,Int})
-	DataArray(Float64, (2, ))
-	DataArray(Float64, (2, 2))
-	DataArray(Float64, (2, 2, 2))
-
-	DataArray(Char, (2, ))
-	DataArray(Char, (2, 2))
-	DataArray(Char, (2, 2, 2))
-
-	# Base.copy(d::DataArray)
-	copy(DataArray([1, 2], falses(2)))
-
-	# Base.deepcopy(d::DataArray)
-	deepcopy(DataArray([1, 2], falses(2)))
-
-	# Base.copy!(dest::DataArray, src::Any)
-	da = DataArray([1, 2], falses(2))
-	copy!(da, [3, 4])
-	da
-
-	# function Base.similar(d::DataArray, T::Type, dims::Dims)
-	similar(DataArray([1, 2], falses(2)), Float64, 2)
-	similar(DataArray([1, 2], falses(2)), Float64, 2, 2)
-	similar(DataArray([1, 2], falses(2)), Float64, 2, 2, 2)
-
-	# Base.size(d::DataArray) = size(d.data)
-	size(DataArray([1, 2], falses(2)))
-	size(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	size(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.ndims(d::DataArray) = ndims(d.data)
-	ndims(DataArray([1, 2], falses(2)))
-	ndims(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	ndims(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.length(d::DataArray) = length(d.data)
-	length(DataArray([1, 2], falses(2)))
-	length(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	length(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.endof(d::DataArray) = endof(d.data)
-	endof(DataArray([1, 2], falses(2)))
-	endof(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	endof(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.eltype{T, N}(d::DataArray{T, N}) = T
-	eltype(DataArray([1, 2], falses(2)))
-	eltype(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	eltype(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.find(da::AbstractDataArray{Bool}) = find(array(da, false))
-	find(DataArray([false, true, true, false]))
-
-	# function array{T}(da::DataArray{T})
-	# array(DataArray([1, 0, 3], [false, true, false]))
-	# array(DataArray([1, 2, 3], [false, false, false]))
-
-	# function array{T}(da::DataArray{T}, replacement::T)
-	array(DataArray([1, 0, 3], [false, true, false]), -1)
-	array(DataArray([1, 2, 3], [false, false, false]), -1)
-
-	# dropna(da::DataArray)
-	dropna(DataArray([1, 0, 3], [false, true, false]))
-	dropna(DataArray([1, 2, 3], [false, false, false]))
-	# dropna{T}(da::AbstractDataVector{T})
-	# dropna(@data([1, NA, 3]))
-
-	# Iterators
-
-	# GetIndex
-	# Base.getindex(x::Vector, inds::AbstractDataVector{Bool})
-	dinds = @data([true, false, false])
-	[1, 2, 3][dinds]
-
-	# Base.getindex(x::Vector, inds::AbstractDataArray{Bool})
-	dinds = @data([true, false, false])
-	[1, 2, 3][dinds]
-
-	# Base.getindex{S, T}(x::Vector{S}, inds::AbstractDataArray{T})
-	dinds = @data([1, 2, NA])
-	@test_throws NAException [1.0, 2.0, 3.0, 4.0][dinds]
-
-	# Base.getindex{S, T}(x::Array{S}, inds::AbstractDataArray{T})
-	dinds = @data([1, 2, NA])
-	@test_throws NAException [1.0 2.0; 3.0 4.0][dinds]
-
-	# Base.getindex(d::DataArray, i::SingleIndex)
-	da = @data([1, 2, NA, 4])
-	da[1]
-	da[3]
-	da[1.0]
-	da[3.0]
-
-	# Base.getindex(d::DataArray, inds::AbstractDataVector{Bool})
-	da = @data([1, 2, NA, 4])
-	dinds = @data([true, false, false, NA])
-	@test_throws NAException da[dinds]
-
-	# Base.getindex(d::DataArray, inds::AbstractDataVector)
-	da = @data([1, 2, NA, 4])
-	dinds = @data([1, 2, NA, 2])
-	@test_throws NAException da[dinds]
-
-	# Base.getindex{T <: Number, N}(d::DataArray{T,N}, inds::BooleanIndex)
-	# da = @data([1, 2, NA, 4])
-	# inds = [1, 2, NA, 2]
-	# da[inds]
-
-	# Base.getindex(d::DataArray, inds::BooleanIndex)
-	# da = @data([1.0, 2.0, NA, 4.0])
-	# inds = [1, 2, NA, 2]
-	# da[inds]
-
-	# Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::MultiIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	inds = [1, 2, 2]
-	da[inds]
-
-	# Base.getindex(d::DataArray, inds::MultiIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	inds = [1, 2, 2]
-	da[inds]
-
-	# Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::BooleanIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	inds = [true, true, false, false]
-	da[inds]
-
-	# Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::MultiIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	inds = [1, 2, 2]
-	da[inds]
-
-	# Base.setindex!(da::DataArray, val::NAtype, i::SingleIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	da[1] = NA
-
-	# Base.setindex!(da::DataArray, val::Any, i::SingleIndex)
-	da = @data([1.0, 2.0, NA, 4.0])
-	da[1] = 3.0
-
-	# Base.setindex!(da::DataArray{NAtype}, val::NAtype, inds::AbstractVector{Bool})
-	# da = DataArray([NA, NA], falses(2))
-	# da[[true, false]] = NA
-
-	# Base.setindex!(da::DataArray{NAtype}, val::NAtype, inds::AbstractVector)
-	# da = DataArray([NA, NA], falses(2))
-	# da[[1, 2]] = NA
-
-	# Base.setindex!(da::DataArray, val::NAtype, inds::AbstractVector{Bool})
-	da = @data([1, 2])
-	da[[true, false]] = NA
-
-	# Base.setindex!(da::DataArray, val::NAtype, inds::AbstractVector)
-	da = @data([1, 2])
-	da[[1, 2]] = NA
-
-	# Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector{Bool})
-	da = @data([1, 2])
-	da[[true, false]] = [3]
-
-	# Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector)
-	da = @data([1, 2])
-	da[[1, 2]] = [3, 4]
-
-	# Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector{Bool})
-	da = @data([1, 2])
-	da[[true, false]] = 5
-
-	# Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector)
-	da = @data([1, 2])
-	da[[1, 2]] = 5
-
-	# Base.setindex!(da::AbstractDataArray, val::Any, inds::AbstractVector{Bool})
-	da = @data([1, 2])
-	da[[true, false]] = 5.0
-
-	# Base.setindex!{T}(da::AbstractDataArray{T}, val::Any, inds::AbstractVector)
-	da = @data([1, 2])
-	da[[1, 2]] = 5
-
-	# isna(a::AbstractArray)
-	isna([1, 2])
-	isna(repeat([1, 2], outer = [1, 2]))
-	isna(repeat([1, 2], outer = [1, 2, 2]))
-
-	# isna(da::DataArray)
-	isna(DataArray([1, 2], falses(2)))
-	isna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	isna(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.isnan(da::DataArray)
-	isnan(DataArray([1, 2], falses(2)))
-	isnan(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	isnan(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.isfinite(da::DataArray)
-	isfinite(DataArray([1, 2], falses(2)))
-	isfinite(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	isfinite(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.start(x::AbstractDataArray)
-	start(DataArray([1, 2], falses(2)))
-	start(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	start(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.next(x::AbstractDataArray, state::Integer)
-	next(DataArray([1, 2], falses(2)), 1)
-	next(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)), 1)
-	next(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)), 1)
-
-	# Base.done(x::AbstractDataArray, state::Integer)
-	done(DataArray([1, 2], falses(2)), 1)
-	done(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)), 1)
-	done(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)), 1)
-
-	# Base.convert{N}(::Type{BitArray{N}}, d::DataArray{BitArray{N}, N})
-
-	# Base.convert{T, N}(::Type{BitArray{N}}, d::DataArray{T, N})
-	# convert(BitArray, DataArray([1, 2], falses(2)))
-	# convert(BitArray, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	# convert(BitArray, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.convert{S, T, N}(::Type{Array{S, N}}, x::DataArray{T, N})
-	convert(Array{Float64}, DataArray([1, 2], falses(2)))
-	convert(Array{Float64}, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	convert(Array{Float64}, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.convert{T, N}(::Type{Array{T, N}}, x::DataArray{T, N})
-	convert(Array, DataArray([1, 2], falses(2)))
-	convert(Array, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	convert(Array, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::Array{T, N})
-	convert(DataArray{Float64}, [1, 2])
-	convert(DataArray{Float64}, repeat([1, 2], outer = [1, 2]))
-	convert(DataArray{Float64}, repeat([1, 2], outer = [1, 2, 2]))
-
-	# Base.convert{T, N}(::Type{DataArray}, x::Array{T, N})
-	convert(DataArray, [1, 2])
-	convert(DataArray, repeat([1, 2], outer = [1, 2]))
-	convert(DataArray, repeat([1, 2], outer = [1, 2, 2]))
-
-	# Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::DataArray{T, N})
-	convert(DataArray{Float64}, DataArray([1, 2], falses(2)))
-	convert(DataArray{Float64}, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	convert(DataArray{Float64}, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.convert{T, N}(::Type{DataArray}, x::DataArray{T, N})
-	convert(DataArray, DataArray([1, 2], falses(2)))
-	convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# int(da::DataArray)
-	int(DataArray([1, 2], falses(2)))
-	int(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	int(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# float(da::DataArray)
-	float(DataArray([1, 2], falses(2)))
-	float(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	float(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# bool(da::DataArray)
-	bool(DataArray([1, 0], falses(2)))
-	bool(DataArray(repeat([1, 0], outer = [1, 2]), falses(2, 2)))
-	bool(DataArray(repeat([1, 0], outer = [1, 2, 2]), falses(2, 2, 2)))
-
-	# Base.hash(a::AbstractDataArray)
-	hash(DataArray([1, 2], falses(2)))
-	hash(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-	hash(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+    using DataArrays, Base.Test
+
+    # DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
+    DataArray([1, 2], falses(2))
+    DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2))
+    DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
+
+    DataArray([1, 2], trues(2))
+    DataArray(repeat([1, 2], outer = [1, 2]), trues(2, 2))
+    DataArray(repeat([1, 2], outer = [1, 2, 2]), trues(2, 2, 2))
+
+    DataArray(['a', 'b'], falses(2))
+    DataArray(repeat(['a', 'b'], outer = [1, 2]), falses(2, 2))
+    DataArray(repeat(['a', 'b'], outer = [1, 2, 2]), falses(2, 2, 2))
+
+    DataArray(['a', 'b'], trues(2))
+    DataArray(repeat(['a', 'b'], outer = [1, 2]), trues(2, 2))
+    DataArray(repeat(['a', 'b'], outer = [1, 2, 2]), trues(2, 2, 2))
+
+    # DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
+    DataArray([1, 2])
+    DataArray(repeat([1, 2], outer = [1, 2]))
+    DataArray(repeat([1, 2], outer = [1, 2, 2]))
+
+    DataArray(['a', 'b'])
+    DataArray(repeat(['a', 'b'], outer = [1, 2]))
+    DataArray(repeat(['a', 'b'], outer = [1, 2, 2]))
+
+    # DataArray(d::Array, m::Array{Bool})
+    DataArray([1, 2], [false, false])
+    DataArray(['a', 'b'], [false, false])
+
+    DataArray([1, 2], [true, true])
+    DataArray(['a', 'b'], [true, true])
+
+    # DataArray(d::BitArray, m::BitArray = falses(size(d)))
+    convert(DataArray, falses(2))
+    convert(DataArray, trues(2))
+
+    # DataArray(d::BitArray, m::BitArray = falses(size(d)))
+    convert(DataArray, falses(2))
+    convert(DataArray, trues(2))
+
+    # DataArray(d::Ranges, m::BitArray = falses(length(d)))
+    convert(DataArray, 1:2)
+    convert(DataArray, 1:2)
+
+    # DataArray(t::Type, dims::Integer...)
+    DataArray(Float64, 2)
+    DataArray(Float64, 2, 2)
+    DataArray(Float64, 2, 2, 2)
+
+    DataArray(Char, 2)
+    DataArray(Char, 2, 2)
+    DataArray(Char, 2, 2, 2)
+
+    # DataArray{N}(t::Type, dims::NTuple{N,Int})
+    DataArray(Float64, (2, ))
+    DataArray(Float64, (2, 2))
+    DataArray(Float64, (2, 2, 2))
+
+    DataArray(Char, (2, ))
+    DataArray(Char, (2, 2))
+    DataArray(Char, (2, 2, 2))
+
+    # Base.copy(d::DataArray)
+    copy(DataArray([1, 2], falses(2)))
+
+    # Base.deepcopy(d::DataArray)
+    deepcopy(DataArray([1, 2], falses(2)))
+
+    # Base.copy!(dest::DataArray, src::Any)
+    da = DataArray([1, 2], falses(2))
+    copy!(da, [3, 4])
+    da
+
+    # function Base.similar(d::DataArray, T::Type, dims::Dims)
+    similar(DataArray([1, 2], falses(2)), Float64, 2)
+    similar(DataArray([1, 2], falses(2)), Float64, 2, 2)
+    similar(DataArray([1, 2], falses(2)), Float64, 2, 2, 2)
+
+    # Base.size(d::DataArray) = size(d.data)
+    size(DataArray([1, 2], falses(2)))
+    size(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    size(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.ndims(d::DataArray) = ndims(d.data)
+    ndims(DataArray([1, 2], falses(2)))
+    ndims(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    ndims(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.length(d::DataArray) = length(d.data)
+    length(DataArray([1, 2], falses(2)))
+    length(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    length(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.endof(d::DataArray) = endof(d.data)
+    endof(DataArray([1, 2], falses(2)))
+    endof(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    endof(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.eltype{T, N}(d::DataArray{T, N}) = T
+    eltype(DataArray([1, 2], falses(2)))
+    eltype(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    eltype(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.find(da::AbstractDataArray{Bool}) = find(array(da, false))
+    find(DataArray([false, true, true, false]))
+
+    # function array{T}(da::DataArray{T})
+    # array(DataArray([1, 0, 3], [false, true, false]))
+    # array(DataArray([1, 2, 3], [false, false, false]))
+
+    # function array{T}(da::DataArray{T}, replacement::T)
+    convert(Vector, DataArray([1, 0, 3], [false, true, false]), -1)
+    convert(Vector, DataArray([1, 2, 3], [false, false, false]), -1)
+
+    # dropna(da::DataArray)
+    dropna(DataArray([1, 0, 3], [false, true, false]))
+    dropna(DataArray([1, 2, 3], [false, false, false]))
+    # dropna{T}(da::AbstractDataVector{T})
+    # dropna(@data([1, NA, 3]))
+
+    # Iterators
+
+    # GetIndex
+    # Base.getindex(x::Vector, inds::AbstractDataVector{Bool})
+    dinds = @data([true, false, false])
+    [1, 2, 3][dinds]
+
+    # Base.getindex(x::Vector, inds::AbstractDataArray{Bool})
+    dinds = @data([true, false, false])
+    [1, 2, 3][dinds]
+
+    # Base.getindex{S, T}(x::Vector{S}, inds::AbstractDataArray{T})
+    dinds = @data([1, 2, NA])
+    @test_throws NAException [1.0, 2.0, 3.0, 4.0][dinds]
+
+    # Base.getindex{S, T}(x::Array{S}, inds::AbstractDataArray{T})
+    dinds = @data([1, 2, NA])
+    @test_throws NAException [1.0 2.0; 3.0 4.0][dinds]
+
+    # Base.getindex(d::DataArray, i::SingleIndex)
+    da = @data([1, 2, NA, 4])
+    da[1]
+    da[3]
+    da[1.0]
+    da[3.0]
+
+    # Base.getindex(d::DataArray, inds::AbstractDataVector{Bool})
+    da = @data([1, 2, NA, 4])
+    dinds = @data([true, false, false, NA])
+    @test_throws NAException da[dinds]
+
+    # Base.getindex(d::DataArray, inds::AbstractDataVector)
+    da = @data([1, 2, NA, 4])
+    dinds = @data([1, 2, NA, 2])
+    @test_throws NAException da[dinds]
+
+    # Base.getindex{T <: Number, N}(d::DataArray{T,N}, inds::BooleanIndex)
+    # da = @data([1, 2, NA, 4])
+    # inds = [1, 2, NA, 2]
+    # da[inds]
+
+    # Base.getindex(d::DataArray, inds::BooleanIndex)
+    # da = @data([1.0, 2.0, NA, 4.0])
+    # inds = [1, 2, NA, 2]
+    # da[inds]
+
+    # Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::MultiIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    inds = [1, 2, 2]
+    da[inds]
+
+    # Base.getindex(d::DataArray, inds::MultiIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    inds = [1, 2, 2]
+    da[inds]
+
+    # Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::BooleanIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    inds = [true, true, false, false]
+    da[inds]
+
+    # Base.getindex{T <: Number, N}(d::DataArray{T, N}, inds::MultiIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    inds = [1, 2, 2]
+    da[inds]
+
+    # Base.setindex!(da::DataArray, val::NAtype, i::SingleIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    da[1] = NA
+
+    # Base.setindex!(da::DataArray, val::Any, i::SingleIndex)
+    da = @data([1.0, 2.0, NA, 4.0])
+    da[1] = 3.0
+
+    # Base.setindex!(da::DataArray{NAtype}, val::NAtype, inds::AbstractVector{Bool})
+    # da = DataArray([NA, NA], falses(2))
+    # da[[true, false]] = NA
+
+    # Base.setindex!(da::DataArray{NAtype}, val::NAtype, inds::AbstractVector)
+    # da = DataArray([NA, NA], falses(2))
+    # da[[1, 2]] = NA
+
+    # Base.setindex!(da::DataArray, val::NAtype, inds::AbstractVector{Bool})
+    da = @data([1, 2])
+    da[[true, false]] = NA
+
+    # Base.setindex!(da::DataArray, val::NAtype, inds::AbstractVector)
+    da = @data([1, 2])
+    da[[1, 2]] = NA
+
+    # Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector{Bool})
+    da = @data([1, 2])
+    da[[true, false]] = [3]
+
+    # Base.setindex!(da::AbstractDataArray, vals::AbstractVector, inds::AbstractVector)
+    da = @data([1, 2])
+    da[[1, 2]] = [3, 4]
+
+    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector{Bool})
+    da = @data([1, 2])
+    da[[true, false]] = 5
+
+    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector)
+    da = @data([1, 2])
+    da[[1, 2]] = 5
+
+    # Base.setindex!(da::AbstractDataArray, val::Any, inds::AbstractVector{Bool})
+    da = @data([1, 2])
+    da[[true, false]] = 5.0
+
+    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Any, inds::AbstractVector)
+    da = @data([1, 2])
+    da[[1, 2]] = 5
+
+    # isna(a::AbstractArray)
+    isna([1, 2])
+    isna(repeat([1, 2], outer = [1, 2]))
+    isna(repeat([1, 2], outer = [1, 2, 2]))
+
+    # isna(da::DataArray)
+    isna(DataArray([1, 2], falses(2)))
+    isna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    isna(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.isnan(da::DataArray)
+    isnan(DataArray([1, 2], falses(2)))
+    isnan(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    isnan(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.isfinite(da::DataArray)
+    isfinite(DataArray([1, 2], falses(2)))
+    isfinite(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    isfinite(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.start(x::AbstractDataArray)
+    start(DataArray([1, 2], falses(2)))
+    start(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    start(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.next(x::AbstractDataArray, state::Integer)
+    next(DataArray([1, 2], falses(2)), 1)
+    next(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)), 1)
+    next(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)), 1)
+
+    # Base.done(x::AbstractDataArray, state::Integer)
+    done(DataArray([1, 2], falses(2)), 1)
+    done(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)), 1)
+    done(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)), 1)
+
+    # Base.convert{N}(::Type{BitArray{N}}, d::DataArray{BitArray{N}, N})
+
+    # Base.convert{T, N}(::Type{BitArray{N}}, d::DataArray{T, N})
+    # convert(BitArray, DataArray([1, 2], falses(2)))
+    # convert(BitArray, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    # convert(BitArray, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.convert{S, T, N}(::Type{Array{S, N}}, x::DataArray{T, N})
+    convert(Array{Float64}, DataArray([1, 2], falses(2)))
+    convert(Array{Float64}, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    convert(Array{Float64}, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.convert{T, N}(::Type{Array{T, N}}, x::DataArray{T, N})
+    convert(Array, DataArray([1, 2], falses(2)))
+    convert(Array, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    convert(Array, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::Array{T, N})
+    convert(DataArray{Float64}, [1, 2])
+    convert(DataArray{Float64}, repeat([1, 2], outer = [1, 2]))
+    convert(DataArray{Float64}, repeat([1, 2], outer = [1, 2, 2]))
+
+    # Base.convert{T, N}(::Type{DataArray}, x::Array{T, N})
+    convert(DataArray, [1, 2])
+    convert(DataArray, repeat([1, 2], outer = [1, 2]))
+    convert(DataArray, repeat([1, 2], outer = [1, 2, 2]))
+
+    # Base.convert{S, T, N}(::Type{DataArray{S, N}}, x::DataArray{T, N})
+    convert(DataArray{Float64}, DataArray([1, 2], falses(2)))
+    convert(DataArray{Float64}, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    convert(DataArray{Float64}, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.convert{T, N}(::Type{DataArray}, x::DataArray{T, N})
+    convert(DataArray, DataArray([1, 2], falses(2)))
+    convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # int(da::DataArray)
+    int(DataArray([1, 2], falses(2)))
+    int(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    int(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # float(da::DataArray)
+    float(DataArray([1, 2], falses(2)))
+    float(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    float(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # bool(da::DataArray)
+    bool(DataArray([1, 0], falses(2)))
+    bool(DataArray(repeat([1, 0], outer = [1, 2]), falses(2, 2)))
+    bool(DataArray(repeat([1, 0], outer = [1, 2, 2]), falses(2, 2, 2)))
+
+    # Base.hash(a::AbstractDataArray)
+    hash(DataArray([1, 2], falses(2)))
+    hash(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    hash(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
 end


### PR DESCRIPTION
This is just a rebased change from #108. Moved `array()` stuff into deprecated but otherwise didn't change the PR.