### PR TITLE
Internal API changes due to 10525

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -87,16 +87,66 @@ function Base.to_index(A::DataArray)
 end
 
 # Fast implementation of checkbounds for DataArray input
-Base._checkbounds(sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz
-function Base._checkbounds{T<:Real}(sz::Int, I::AbstractDataArray{T})
-    anyna(I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
-    extr = daextract(I)
-    b = true
-    for i = 1:length(I)
-        @inbounds v = unsafe_getindex_notna(I, extr, i)
-        b &= Base._checkbounds(sz, v)
+# This overrides an internal API that changed after #10525
+if VERSION < v"0.4-dev+5194"
+    Base.checkbounds(sz::Int, I::AbstractDataVector{Bool}) =
+        length(I) == sz || throw(BoundsError())
+    function Base.checkbounds{T<:Real}(sz::Int, I::AbstractDataArray{T})
+        anyna(I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
+        extr = daextract(I)
+        for i = 1:length(I)
+            @inbounds v = unsafe_getindex_notna(I, extr, i)
+            checkbounds(sz, v)
+        end
     end
-    b
+else
+    Base._checkbounds(sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz
+    function Base._checkbounds{T<:Real}(sz::Int, I::AbstractDataArray{T})
+        anyna(I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
+        extr = daextract(I)
+        b = true
+        for i = 1:length(I)
+            @inbounds v = unsafe_getindex_notna(I, extr, i)
+            b &= Base._checkbounds(sz, v)
+        end
+        b
+    end
+end
+
+# Indexing uses undocumented APIs to determine the resulting shape. These APIs 
+# changed to support indices like `:`, which need the array to know the shape
+if VERSION < v"0.4-dev+5194" # Merge commit of Julialang/julia#10525
+    index_shape(A, I...) = Base.index_shape(I...)
+    _lengths() = ()
+    _lengths(i, I...) = tuple(length(i), _lengths(I...)...)
+    index_lengths(A, I...) = _lengths(I...)
+    function throw_setindex_mismatch(X, I)
+        if length(I) == 1
+            throw(DimensionMismatch("tried to assign $(length(X)) elements to $(I[1]) destinations"))
+        else
+            throw(DimensionMismatch("tried to assign $(Base.dims2string(size(X))) array to $(Base.dims2string(I)) destination"))
+        end
+    end
+    setindex_shape_check(X::AbstractArray) =
+        (length(X)==1 ||    throw_setindex_mismatch(X,()))
+    setindex_shape_check(X::AbstractArray, i::Int) =
+        (length(X)==i ||    throw_setindex_mismatch(X, (i,)))
+    setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int) =
+        (length(X)==i ||    throw_setindex_mismatch(X, (i,)))
+    setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int, j::Int) =
+        (length(X)==i*j ||  throw_setindex_mismatch(X, (i,j)))
+    function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Int, j::Int)
+        if length(X) != i*j
+            throw_setindex_mismatch(X, (i,j))
+        end
+        sx1 = size(X,1)
+        if !(i == 1 || i == sx1 || sx1 == 1)
+            throw_setindex_mismatch(X, (i,j))
+        end
+    end
+    setindex_shape_check(X, I::Int...) = nothing # Non-arrays broadcast to all idxs
+else
+    import Base: index_shape, index_lengths, setindex_shape_check
 end
 
 # Fallbacks to avoid ambiguity
@@ -145,7 +195,7 @@ end
 end
 
 function _getindex{T}(A::DataArray{T}, I::@compat Tuple{Vararg{Union(Int,AbstractVector)}})
-    shape = Base.index_shape(A, I...)
+    shape = index_shape(A, I...)
     _getindex!(DataArray(Array(T, shape), falses(shape)), A, I...)
 end
 
@@ -246,8 +296,8 @@ end
         end
     else
         X = x
-        idxlens = @ncall N Base.index_lengths A I
-        @ncall N Base.setindex_shape_check X (d->idxlens[d])
+        idxlens = @ncall N index_lengths A I
+        @ncall N setindex_shape_check X (d->idxlens[d])
         k = 1
         if isa(A, PooledDataArray) && isa(X, PooledDataArray)
             # When putting one PDA into another, first unify the pools

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -87,15 +87,16 @@ function Base.to_index(A::DataArray)
 end
 
 # Fast implementation of checkbounds for DataArray input
-Base.checkbounds(sz::Int, I::AbstractDataVector{Bool}) =
-    length(I) == sz || throw(BoundsError())
-function Base.checkbounds{T<:Real}(sz::Int, I::AbstractDataArray{T})
+Base._checkbounds(sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz
+function Base._checkbounds{T<:Real}(sz::Int, I::AbstractDataArray{T})
     anyna(I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
     extr = daextract(I)
+    b = true
     for i = 1:length(I)
         @inbounds v = unsafe_getindex_notna(I, extr, i)
-        checkbounds(sz, v)
+        b &= Base._checkbounds(sz, v)
     end
+    b
 end
 
 # Fallbacks to avoid ambiguity


### PR DESCRIPTION
There were a few internal APIs that I changed in JuliaLang/julia#10525.  This is a start at fixing some of your uses of them.  ~~I think I got everything except a few assumptions about how Base.checkbounds will work with NAType, so this fails in a few places where you expect checkbounds to throw an NAException -- it is now a MethodError.~~

There is a lot more that you could do to adjust to a post-10525 world.  Let me know if you have any questions along the way.