### PR TITLE
isna() for scalar case

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -447,6 +447,8 @@ isna(da::DataArray) = copy(da.na) # -> BitArray
 #' a = @data([1, 2, 3])
 #' isna(a, 1)
 #' isna(a, 1:2)
+isna(da::DataArray, I::Any) = getindex(da.na, I)
+
 @nsplat N function isna(da::DataArray, I::NTuple{N,Any}...)
     getindex(da.na, I...)
 end


### PR DESCRIPTION
It significantly reduces memory allocation overhead in `DataFrames` for me on 0.4.