### PR TITLE
Add symbol method for NA.

### DIFF
--- a/src/natype.jl
+++ b/src/natype.jl
@@ -20,6 +20,7 @@ end
 const NA = NAtype()
 
 Base.show(io::IO, x::NAtype) = print(io, "NA")
+Base.symbol(x::NAtype) = :NA
 
 type NAException <: Exception
     msg::String

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -63,4 +63,6 @@ module TestNAs
     @test_throws NAException for v in each_failna(dv); end
     @test collect(each_dropna(dv)) == a
     @test collect(each_replacena(dv, 4)) == [4, 4, a..., 4]
+
+    @test symbol(NA) == :NA
 end


### PR DESCRIPTION
I needed to define this for a case like this:

``` julia
julia> using DataFrames

julia> df = DataFrame(Test = @data ["a", NA, "c"])
3x1 DataFrame
| Row | Test |
|-----|------|
| 1   | "a"  |
| 2   | NA   |
| 3   | "c"  |

julia> test = countmap(df[:Test])
Dict{Union(NAtype,ASCIIString),Int64} with 3 entries:
  "c" => 1
  NA  => 1
  "a" => 1

julia> test_count = DataFrame(;[symbol(k) => v for (k, v) in test]...)
ERROR: `symbol` has no method matching symbol(::NAtype)
 in anonymous at no file

julia> Base.symbol(x::NAtype) = :NA
symbol (generic function with 7 methods)

julia> test_count = DataFrame(;[symbol(k) => v for (k, v) in test]...)
1x3 DataFrame
| Row | NA | c | a |
|-----|----|---|---|
| 1   | 1  | 1 | 1 |
```
