### PR TITLE
Fix 0.4 deprecations

### DIFF
--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -47,14 +47,14 @@ function Base.shift!{T}(dv::DataVector{T})
     end
 end
 
-function Base.splice!(dv::DataVector, inds::Union(Integer, UnitRange{Int}))
+function Base.splice!(dv::DataVector, inds::(@compat Union{Integer, UnitRange{Int}}))
     v = dv[inds]
     deleteat!(dv.data, inds)
     deleteat!(dv.na, inds)
     v
 end
 
-function Base.splice!(dv::DataVector, inds::Union(Integer, UnitRange{Int}), ins::AbstractVector)
+function Base.splice!(dv::DataVector, inds::(@compat Union{Integer, UnitRange{Int}}), ins::AbstractVector)
     # We cannot merely use the implementation in Base because this
     # needs to handle NA in the replacement vector
     v = dv[inds]
@@ -147,13 +147,13 @@ Base.shift!(pdv::PooledDataVector) = pdv.pool[shift!(pdv.refs)]
 
 Base.reverse(x::AbstractDataVector) = x[end:-1:1]
 
-function Base.splice!(pdv::PooledDataVector, inds::Union(Integer, UnitRange{Int}))
+function Base.splice!(pdv::PooledDataVector, inds::(@compat Union{Integer, UnitRange{Int}}))
     v = pdv[inds]
     deleteat!(pdv.refs, inds)
     v
 end
 
-function Base.splice!(pdv::PooledDataVector, inds::Union(Integer, UnitRange{Int}), ins::AbstractVector)
+function Base.splice!(pdv::PooledDataVector, inds::(@compat Union{Integer, UnitRange{Int}}), ins::AbstractVector)
     v = pdv[inds]
     splice!(pdv.refs, inds, [getpoolidx(pdv, v) for v in ins])
     v

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,7 +2,7 @@
 #       when the deprecation is removed
 import Base.@deprecate
 import Base.Operators: /
-@deprecate (/)(x::Union(NAtype,Number),A::AbstractDataArray)    x ./ A
+@deprecate (/)(x::(@compat Union{NAtype,Number}),A::AbstractDataArray)    x ./ A
 
 #' @description
 #'

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -20,11 +20,11 @@ function StatsBase.addcounts!{T,U,W}(cm::Dict{U,W}, x::AbstractDataArray{T}, wv:
 end
 
 function StatsBase.countmap{T}(x::AbstractDataArray{T})
-    addcounts!(Dict{Union(T, NAtype), Int}(), x)
+    addcounts!(Dict{(@compat Union{T, NAtype}), Int}(), x)
 end
 
 function StatsBase.countmap{T,W}(x::AbstractDataArray{T}, wv::WeightVec{W})
-    addcounts!(Dict{Union(T, NAtype), W}(), x, wv)
+    addcounts!(Dict{(@compat Union{T, NAtype}), W}(), x, wv)
 end
 
 function cut{S, T}(x::AbstractVector{S}, breaks::Vector{T})

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -126,7 +126,7 @@ else
     end
 end
 
-# Indexing uses undocumented APIs to determine the resulting shape. These APIs 
+# Indexing uses undocumented APIs to determine the resulting shape. These APIs
 # changed to support indices like `:`, which need the array to know the shape
 if VERSION < v"0.4-dev+5194" # Merge commit of Julialang/julia#10525
     index_shape(A, I...) = Base.index_shape(I...)
@@ -188,7 +188,7 @@ end
 
 # Vector case
 @ngenerate N typeof(dest) function _getindex!(dest::DataArray, src::DataArray,
-                                              I::NTuple{N,Union(Int,AbstractVector)}...)
+                                              I::NTuple{N,(@compat Union{Int,AbstractVector})}...)
     Base.checksize(dest, I...)
     stride_1 = 1
     @nexprs N d->(stride_{d+1} = stride_d*size(src,d))
@@ -207,18 +207,18 @@ end
     dest
 end
 
-function _getindex{T}(A::DataArray{T}, I::@compat Tuple{Vararg{Union(Int,AbstractVector)}})
+function _getindex{T}(A::DataArray{T}, I::@compat Tuple{Vararg{Union{Int,AbstractVector}}})
     shape = index_shape(A, I...)
     _getindex!(DataArray(Array(T, shape), falses(shape)), A, I...)
 end
 
 if VERSION >= v"0.4.0-dev+5578"
-    @nsplat N function Base.getindex(A::DataArray, I::NTuple{N,Union(Real,AbstractVector)}...)
+    @nsplat N function Base.getindex(A::DataArray, I::NTuple{N,(@compat Union{Real,AbstractVector})}...)
         checkbounds(A, I...)
         _getindex(A, Base.to_indexes(I...))
     end
 else
-    @nsplat N function Base.getindex(A::DataArray, I::NTuple{N,Union(Real,AbstractVector)}...)
+    @nsplat N function Base.getindex(A::DataArray, I::NTuple{N,(@compat Union{Real,AbstractVector})}...)
         checkbounds(A, I...)
         _getindex(A, Base.to_index(I...))
     end
@@ -253,7 +253,7 @@ end
 end
 
 # Vector case
-@nsplat N function Base.getindex(A::PooledDataArray, I::NTuple{N,Union(Real,AbstractVector)}...)
+@nsplat N function Base.getindex(A::PooledDataArray, I::NTuple{N,(@compat Union{Real,AbstractVector})}...)
     PooledDataArray(RefArray(getindex(A.refs, I...)), copy(A.pool))
 end
 
@@ -291,7 +291,7 @@ end
 ## setindex!: both DataArray and PooledDataArray
 
 @ngenerate N typeof(A) function Base.setindex!(A::AbstractDataArray, x,
-                                               J::NTuple{N,Union(Real,AbstractArray)}...)
+                                               J::NTuple{N,(@compat Union{Real,AbstractArray})}...)
     if !isa(x, AbstractArray) && isa(A, PooledDataArray)
         # Only perform one pool lookup when assigning a scalar value in
         # a PooledDataArray

--- a/src/natype.jl
+++ b/src/natype.jl
@@ -22,7 +22,7 @@ const NA = NAtype()
 Base.show(io::IO, x::NAtype) = print(io, "NA")
 
 type NAException <: Exception
-    msg::String
+    msg::UTF8String
 end
 NAException() = NAException("NA found")
 

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -87,9 +87,9 @@ end
 # NA, it returns NA. Otherwise we will fall back to the implementation
 # in Base, which is slow because it's type-unstable, but guarantees the
 # correct semantics
-typealias SafeMapFuns Union(Base.IdFun, Base.AbsFun, Base.Abs2Fun,
-                            Base.ExpFun, Base.LogFun, Base.CentralizedAbs2Fun)
-typealias SafeReduceFuns Union(Base.AddFun, Base.MulFun, Base.MaxFun, Base.MinFun)
+typealias SafeMapFuns @compat Union{Base.IdFun, Base.AbsFun, Base.Abs2Fun,
+                            Base.ExpFun, Base.LogFun, Base.CentralizedAbs2Fun}
+typealias SafeReduceFuns @compat Union{Base.AddFun, Base.MulFun, Base.MaxFun, Base.MinFun}
 function Base._mapreduce(f::SafeMapFuns, op::SafeReduceFuns, A::DataArray)
     any(A.na) && return NA
     Base._mapreduce(f, op, A.data)
@@ -104,7 +104,7 @@ function Base.mapreduce(f, op::Function, A::DataArray; skipna::Bool=false)
 end
 
 # To silence deprecations, but could be more efficient
-Base.mapreduce(f, op::Union(Base.OrFun, Base.AndFun), A::DataArray; skipna::Bool=false) =
+Base.mapreduce(f, op::(@compat Union{Base.OrFun, Base.AndFun}), A::DataArray; skipna::Bool=false) =
     skipna ? _mapreduce_skipna(f, op, A) : Base._mapreduce(f, op, A)
 
 Base.mapreduce(f, op, A::DataArray; skipna::Bool=false) =
@@ -120,7 +120,7 @@ for (fn, op) in ((:(Base.sum), Base.AddFun()),
                  (:(Base.minimum), Base.MinFun()),
                  (:(Base.maximum), Base.MaxFun()))
     @eval begin
-        $fn(f::Union(Function,Base.Func{1}), a::DataArray; skipna::Bool=false) =
+        $fn(f::(@compat Union{Function,Base.Func{1}}), a::DataArray; skipna::Bool=false) =
             mapreduce(f, $op, a; skipna=skipna)
         $fn(a::DataArray; skipna::Bool=false) =
             mapreduce(Base.IdFun(), $op, a; skipna=skipna)
@@ -169,7 +169,7 @@ end
 function Base.var(A::DataArray; corrected::Bool=true, mean=nothing, skipna::Bool=false)
     mean == 0 ? Base.varzm(A; corrected=corrected, skipna=skipna) :
     mean == nothing ? varm(A, Base.mean(A; skipna=skipna); corrected=corrected, skipna=skipna) :
-    isa(mean, Union(Number, NAtype)) ?
+    isa(mean, (@compat Union{Number, NAtype})) ?
         varm(A, mean; corrected=corrected, skipna=skipna) :
         throw(ErrorException("Invalid value of mean."))
 end

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -15,7 +15,7 @@ end
 datachunks(o::Base.Order.Perm, v::AbstractVector{Int}) = (v, o.data.na.chunks)
 datachunks(o::Base.Order.DirectOrdering, v::DataVector) = (v.data, v.na.chunks)
 
-function nas2left!(v::Union(AbstractVector{Int}, DataVector), o::Base.Order.Ordering, lo::Int=1, hi::Int=length(v))
+function nas2left!(v::(@compat Union{AbstractVector{Int}, DataVector}), o::Base.Order.Ordering, lo::Int=1, hi::Int=length(v))
     data, chunks = datachunks(o, v)
 
     i = lo
@@ -37,7 +37,7 @@ function nas2left!(v::Union(AbstractVector{Int}, DataVector), o::Base.Order.Orde
     return i, hi
 end
 
-function nas2right!(v::Union(AbstractVector{Int}, DataVector), o::Base.Order.Ordering, lo::Int=1, hi::Int=length(v))
+function nas2right!(v::(@compat Union{AbstractVector{Int}, DataVector}), o::Base.Order.Ordering, lo::Int=1, hi::Int=length(v))
     data, chunks = datachunks(o, v)
 
     i = hi

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -2,6 +2,7 @@ module TestExtras
     using Base.Test
     using DataArrays
     using StatsBase
+    using Compat
 
     ##########
     ## countmap
@@ -9,8 +10,8 @@ module TestExtras
 
     d = @data [NA,3,3]
     w = weights([1.1,2.2,3.3])
-    cm = Dict{Union(Int, NAtype), Int}([(NA, 1), (3, 2)])
-    cmw = Dict{Union(Int, NAtype), Real}([(NA, 1.1), (3, 5.5)])
+    cm = Dict{(@compat Union{Int, NAtype}), Int}([(NA, 1), (3, 2)])
+    cmw = Dict{(@compat Union{Int, NAtype}), Real}([(NA, 1.1), (3, 5.5)])
     @assert isequal(countmap(d), cm)
     @assert isequal(countmap(d, w), cmw)
 

--- a/test/literals.jl
+++ b/test/literals.jl
@@ -46,7 +46,7 @@ module TestLiterals
     @test typeof(dv) == DataMatrix{Any}
 
     if VERSION >= v"0.4.0-"
-      println("Testing parsing 0.3 cell literal syntax, (4) warnings expected")
+      println("Testing parsing 0.3 cell literal syntax, (6) warnings expected")
     end
     dv = @data {1, NA, 3}
     @test isequal(dv,
@@ -73,8 +73,7 @@ module TestLiterals
                   DataArray(Any[1 0; 3 4],
                             [false true; false false]))
 
-    dm = @data {1 NA;
-                3 4}
+    dm = @data {1 NA; 3 4}
     @test isequal(dm,
                   DataArray(Any[1 0; 3 4],
                             [false true; false false]))
@@ -127,8 +126,7 @@ module TestLiterals
     @test isequal(pdm,
                   PooledDataArray([1 0; 3 4],
                                   [false true; false false]))
-    pdm = @pdata {1 NA;
-                  3 4}
+    pdm = @pdata {1 NA; 3 4}
     @test isequal(pdm,
                   PooledDataArray(Any[1 0; 3 4],
                                   [false true; false false]))

--- a/test/newtests/dataarray.jl
+++ b/test/newtests/dataarray.jl
@@ -2,7 +2,7 @@
 # TODO: Pull in existing tests into this file
 # TODO: Rename to TestDataArray
 module TestDataArrays
-    using DataArrays, Base.Test
+    using DataArrays, Base.Test, Compat
 
     # DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
     DataArray([1, 2], falses(2))
@@ -148,8 +148,8 @@ module TestDataArrays
     da = @data([1, 2, NA, 4])
     da[1]
     da[3]
-    da[1.0]
-    da[3.0]
+    # da[1.0] deprecated
+    # da[3.0] deprecated
 
     # Base.getindex(d::DataArray, inds::AbstractDataVector{Bool})
     da = @data([1, 2, NA, 4])
@@ -223,11 +223,11 @@ module TestDataArrays
     da = @data([1, 2])
     da[[1, 2]] = [3, 4]
 
-    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector{Bool})
+    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, AbstractString, T), inds::AbstractVector{Bool})
     da = @data([1, 2])
     da[[true, false]] = 5
 
-    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, String, T), inds::AbstractVector)
+    # Base.setindex!{T}(da::AbstractDataArray{T}, val::Union(Number, AbstractString, T), inds::AbstractVector)
     da = @data([1, 2])
     da[[1, 2]] = 5
 
@@ -311,20 +311,20 @@ module TestDataArrays
     convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
     convert(DataArray, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
 
-    # int(da::DataArray)
-    int(DataArray([1, 2], falses(2)))
-    int(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-    int(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
+    # round(Int, da::DataArray)
+    round(Int, DataArray([1, 2], falses(2)))
+    round(Int, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+    round(Int, DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
 
     # float(da::DataArray)
     float(DataArray([1, 2], falses(2)))
     float(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
     float(DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2)))
 
-    # bool(da::DataArray)
-    bool(DataArray([1, 0], falses(2)))
-    bool(DataArray(repeat([1, 0], outer = [1, 2]), falses(2, 2)))
-    bool(DataArray(repeat([1, 0], outer = [1, 2, 2]), falses(2, 2, 2)))
+    # map(Bool, da::DataArray)
+    @compat map(Bool, DataArray([1, 0], falses(2)))
+    @compat map(Bool, DataArray(repeat([1, 0], outer = [1, 2]), falses(2, 2)))
+    @compat map(Bool, DataArray(repeat([1, 0], outer = [1, 2, 2]), falses(2, 2, 2)))
 
     # Base.hash(a::AbstractDataArray)
     hash(DataArray([1, 2], falses(2)))

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -78,6 +78,7 @@ function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
     R[ridx...] = r1
 
     first = true
+
     Base.cartesianmap(itershape) do idxs...
         if first
             first = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@
 
 using Base.Test
 using DataArrays
+using Compat
 
 my_tests = ["abstractarray.jl",
             "booleans.jl",


### PR DESCRIPTION
Union(..) -> Union{..}, String -> AbstractString, FloatingPoint -> AbstractFloat

The two remaining messages are:

1. cartesianmap
2. {..} syntax (Note: replacing with Any[..] fails