### PR TITLE
An uninitialized DataArray is now convertable.

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -583,7 +583,11 @@ Base.convert{T, N}(::Type{DataArray}, x::AbstractArray{T, N}) =
 #' dv_alt = convert(DataVector{Float64}, dv)
 function Base.convert{S, T, N}(::Type{DataArray{S, N}},
                                x::DataArray{T, N}) # -> DataArray{S, N}
-    return DataArray(convert(Array{S}, x.data), x.na)
+    v = Array{S,N}(size(x.data)...)
+    @inbounds for i = find(!x.na)
+        v[i] = convert(S, x.data[i])
+    end
+    return DataArray(v, x.na)
 end
 
 #' @description

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -584,8 +584,10 @@ Base.convert{T, N}(::Type{DataArray}, x::AbstractArray{T, N}) =
 function Base.convert{S, T, N}(::Type{DataArray{S, N}},
                                x::DataArray{T, N}) # -> DataArray{S, N}
     v = similar(x.data, S)
-    @inbounds for i = find(!x.na)
-        v[i] = convert(S, x.data[i])
+    @inbounds for i = 1:length(x)
+        if !x.na[i]
+            v[i] = convert(S, x.data[i])
+        end
     end
     return DataArray(v, x.na)
 end

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -583,7 +583,7 @@ Base.convert{T, N}(::Type{DataArray}, x::AbstractArray{T, N}) =
 #' dv_alt = convert(DataVector{Float64}, dv)
 function Base.convert{S, T, N}(::Type{DataArray{S, N}},
                                x::DataArray{T, N}) # -> DataArray{S, N}
-    v = Array{S,N}(size(x.data)...)
+    v = similar(x.data, S)
     @inbounds for i = find(!x.na)
         v[i] = convert(S, x.data[i])
     end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -19,4 +19,9 @@ module TestConversions
     # Should raise errors:
     # matrix(dm)
     # convert(Matrix{Float64}, dm)
+
+    a = DataArray(Any,2)
+    convert(DataArray{Integer}, a)
+    a[1] = 2
+    convert(DataArray{Integer}, a)
 end


### PR DESCRIPTION
Simple test that previously caused an error:
> convert (DataArray{Integer,1},DataArray(Any,2))

That might seem pointless but consider this:
> a = DataArray(Any,2)
> a[1] = 2;
> a[2] = NA;
> convert(DataArray{Integer,1},a)
All values are defined, but the conversion still failed. This commit fixes this.