### PR TITLE
Allow replacing with results of a function

### DIFF
--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -25,6 +25,7 @@ module DataArrays
            each_failna,
            each_dropna,
            each_replacena,
+           each_replacenawithfunctionresult,
            EachFailNA,
            EachDropNA,
            EachReplaceNA,

--- a/src/abstractdataarray.jl
+++ b/src/abstractdataarray.jl
@@ -168,3 +168,19 @@ function Base.next(itr::EachReplaceNA, ind::Integer)
     item = isna(itr.da, ind) ? itr.replacement : itr.da[ind]
     (item, ind + 1)
 end
+
+type EachReplaceNAWithFunctionResult{T}
+    da::AbstractDataArray{T}
+    f::Function
+    withData::Bool
+end
+function each_replacenawithfunctionresult(da::AbstractDataArray, f::Function, withData::Bool)
+  EachReplaceNAWithFunctionResult(da, f, withData)
+end
+
+Base.start(itr::EachReplaceNAWithFunctionResult) = 1
+Base.done(itr::EachReplaceNAWithFunctionResult, ind::Int) = ind > length(itr.da)
+function Base.next(itr::EachReplaceNAWithFunctionResult, ind::Integer)
+  item = isna(itr.da, ind) ? (itr.withData ? itr.f(itr.da) : itr.f()) : itr.da[ind]
+  (item, ind + 1)
+end

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -63,4 +63,9 @@ module TestNAs
     @test_throws NAException for v in each_failna(dv); end
     @test collect(each_dropna(dv)) == a
     @test collect(each_replacena(dv, 4)) == [4, 4, a..., 4]
+
+    dv = DataArray(Array(1:6), push!(fill(false, 3),fill(true, 3)...))
+    a = dropna(dv)
+    f = x -> round(Int, mean(dropna(x)))
+    @test collect(each_replacenawithfunctionresult(dv, f, true)) == [1, 2, 3, 2, 2, 2]
 end


### PR DESCRIPTION
Create another type which can replace with results of evaluating a function, optionally providing the data array itself as an argument. Use case: Replace with samples drawn from the distribution of non NA values. 