### PR TITLE
Fix concat deprecation warning in `cut`

### DIFF
--- a/src/extras.jl
+++ b/src/extras.jl
@@ -61,7 +61,7 @@ function cut{S, T}(x::AbstractVector{S}, breaks::Vector{T})
     PooledDataArray(RefArray(refs), pool)
 end
 
-cut(x::AbstractVector, ngroups::Integer) = cut(x, quantile(x, [1 : ngroups - 1] / ngroups))
+cut(x::AbstractVector, ngroups::Integer) = cut(x, quantile(x, collect(1 : ngroups - 1) / ngroups))
 
 function rep{T <: Integer}(x::AbstractVector, lengths::AbstractVector{T})
     if length(x) != length(lengths)


### PR DESCRIPTION
```
WARNING: [a] concatenation is deprecated; use collect(a) instead
 in depwarn at deprecated.jl:73
 in oldstyle_vcat_warning at ./abstractarray.jl:29
 in cut at .../.julia/v0.4/DataArrays/src/extras.jl:64
```