### PR TITLE
Make DataArrays ready for 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: julia
 julia:
   - nightly
   - 0.4
-  - 0.3
 os:
   - linux
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("DataArrays"); Pkg.test("DataArrays", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("DataArrays")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 StatsBase 0.3
-Compat 0.2.12-
+Compat 0.2.17
 Reexport

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6641" && __precompile__()
+__precompile__()
 
 module DataArrays
     using Base.Cartesian, Compat, Reexport

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -2,9 +2,13 @@ VERSION >= v"0.4.0-dev+6641" && __precompile__()
 
 module DataArrays
     using Base.Cartesian, Compat, Reexport
+    import Compat.String
     @reexport using StatsBase
 
     const DEFAULT_POOLED_REF_TYPE = UInt32
+
+    import Base: ==, !=, >, <, >=, <=, +, -, *, !, &, |, $, ^, /,
+      .==, .!=, .>, .<, .>=, .<=, .+, .-, .*, .%, ./, .\, .^
 
     export @data,
            @pdata,

--- a/src/abstractdataarray.jl
+++ b/src/abstractdataarray.jl
@@ -53,7 +53,7 @@ Base.done(x::AbstractDataArray, state::Integer) = state > length(x)
 #' a = [1, 2, 3]
 #' isna(a)
 isna{T}(a::AbstractArray{T}) =
-    NAtype <: T ? bitpack(map(x->isa(x, NAtype), a)) : falses(size(a)) # -> BitArray
+    NAtype <: T ? BitArray(map(x->isa(x, NAtype), a)) : falses(size(a)) # -> BitArray
 
 #' @description
 #'
@@ -125,8 +125,9 @@ type EachFailNA{T}
     da::AbstractDataArray{T}
 end
 each_failna{T}(da::AbstractDataArray{T}) = EachFailNA(da)
+Base.length(itr::EachFailNA) = length(itr.da)
 Base.start(itr::EachFailNA) = 1
-Base.done(itr::EachFailNA, ind::Integer) = ind > length(itr.da)
+Base.done(itr::EachFailNA, ind::Integer) = ind > length(itr)
 function Base.next(itr::EachFailNA, ind::Integer)
     if isna(itr.da[ind])
         throw(NAException())
@@ -146,6 +147,7 @@ function _next_nonna_ind{T}(da::AbstractDataArray{T}, ind::Int)
     end
     ind
 end
+Base.length(itr::EachDropNA) = length(itr.da) - sum(itr.da.na)
 Base.start(itr::EachDropNA) = _next_nonna_ind(itr.da, 0)
 Base.done(itr::EachDropNA, ind::Int) = ind > length(itr.da)
 function Base.next(itr::EachDropNA, ind::Int)
@@ -162,8 +164,9 @@ end
 function each_replacena(replacement::Any)
     x -> each_replacena(x, replacement)
 end
+Base.length(itr::EachReplaceNA) = length(itr.da)
 Base.start(itr::EachReplaceNA) = 1
-Base.done(itr::EachReplaceNA, ind::Integer) = ind > length(itr.da)
+Base.done(itr::EachReplaceNA, ind::Integer) = ind > length(itr)
 function Base.next(itr::EachReplaceNA, ind::Integer)
     item = isna(itr.da, ind) ? itr.replacement : itr.da[ind]
     (item, ind + 1)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -10,10 +10,10 @@ if isdefined(Base.Broadcast, :type_minus)
     const _type_pow = type_pow
 else
     using Base.Broadcast: promote_op
-    _type_minus(T, S) = promote_op(Base.SubFun(), T, S)
-    _type_rdiv(T, S) = promote_op(Base.RDivFun(), T, S)
-    _type_ldiv(T, S) = promote_op(Base.LDivFun(), T, S)
-    _type_pow(T, S) = promote_op(Base.PowFun(), T, S)
+    _type_minus(T, S) = promote_op(@functorize(-), T, S)
+    _type_rdiv(T, S) = promote_op(@functorize(/), T, S)
+    _type_ldiv(T, S) = promote_op(@functorize(\), T, S)
+    _type_pow(T, S) = promote_op(@functorize(^), T, S)
 end
 
 # Check that all arguments are broadcast compatible with shape
@@ -38,10 +38,10 @@ end
 # Get ref for value for a PooledDataArray, adding to the pool if
 # necessary
 _unsafe_pdaref!(Bpool, Brefdict::Dict, val::NAtype) = 0
-function _unsafe_pdaref!{K,V}(Bpool, Brefdict::Dict{K,V}, val)
+function _unsafe_pdaref!(Bpool, Brefdict::Dict, val)
     @get! Brefdict val begin
         push!(Bpool, val)
-        convert(V, length(Bpool))
+        length(Bpool)
     end
 end
 
@@ -49,7 +49,7 @@ end
 # gives good performance at the cost of 2^narrays branches.
 function gen_na_conds(f, nd, arrtype, outtype, daidx=find([arrtype...] .!= AbstractArray), pos=1, isna=())
     if pos > length(daidx)
-        args = Any[symbol("v_$(k)") for k = 1:length(arrtype)]
+        args = Any[Symbol("v_$(k)") for k = 1:length(arrtype)]
         for i = 1:length(daidx)
             if isna[i]
                 args[daidx[i]] = NA
@@ -69,13 +69,13 @@ function gen_na_conds(f, nd, arrtype, outtype, daidx=find([arrtype...] .!= Abstr
     else
         k = daidx[pos]
         quote
-            if $(symbol("isna_$(k)"))
+            if $(Symbol("isna_$(k)"))
                 $(gen_na_conds(f, nd, arrtype, outtype, daidx, pos+1, tuple(isna..., true)))
             else
                 $(if arrtype[k] == DataArray
-                    :(@inbounds $(symbol("v_$(k)")) = $(symbol("data_$(k)"))[$(symbol("state_$(k)_0"))])
+                    :(@inbounds $(Symbol("v_$(k)")) = $(Symbol("data_$(k)"))[$(Symbol("state_$(k)_0"))])
                 else
-                    :(@inbounds $(symbol("v_$(k)")) = $(symbol("pool_$(k)"))[$(symbol("r_$(k)"))])
+                    :(@inbounds $(Symbol("v_$(k)")) = $(Symbol("pool_$(k)"))[$(Symbol("r_$(k)"))])
                 end)
                 $(gen_na_conds(f, nd, arrtype, outtype, daidx, pos+1, tuple(isna..., false)))
             end
@@ -90,7 +90,7 @@ end
 function gen_broadcast_dataarray(nd::Int, arrtype::@compat(Tuple{Vararg{DataType}}), outtype, f::Function)
     F = Expr(:quote, f)
     narrays = length(arrtype)
-    As = [symbol("A_$(i)") for i = 1:narrays]
+    As = [Symbol("A_$(i)") for i = 1:narrays]
     dataarrays = find([arrtype...] .== DataArray)
     abstractdataarrays = find([arrtype...] .!= AbstractArray)
     have_fastpath = outtype == DataArray && all(x->!(x <: PooledDataArray), arrtype)
@@ -102,13 +102,13 @@ function gen_broadcast_dataarray(nd::Int, arrtype::@compat(Tuple{Vararg{DataType
             # Set up input DataArray/PooledDataArrays
             $(Expr(:block, [
                 arrtype[k] == DataArray ? quote
-                    $(symbol("na_$(k)")) = $(symbol("A_$(k)")).na.chunks
-                    $(symbol("data_$(k)")) = $(symbol("A_$(k)")).data
-                    $(symbol("state_$(k)_0")) = $(symbol("state_$(k)_$(nd)")) = 1
-                    @nexprs $nd d->($(symbol("skip_$(k)_d")) = size($(symbol("data_$(k)")), d) == 1)
+                    $(Symbol("na_$(k)")) = $(Symbol("A_$(k)")).na.chunks
+                    $(Symbol("data_$(k)")) = $(Symbol("A_$(k)")).data
+                    $(Symbol("state_$(k)_0")) = $(Symbol("state_$(k)_$(nd)")) = 1
+                    @nexprs $nd d->($(Symbol("skip_$(k)_d")) = size($(Symbol("data_$(k)")), d) == 1)
                 end : arrtype[k] == PooledDataArray ? quote
-                    $(symbol("refs_$(k)")) = $(symbol("A_$(k)")).refs
-                    $(symbol("pool_$(k)")) = $(symbol("A_$(k)")).pool
+                    $(Symbol("refs_$(k)")) = $(Symbol("A_$(k)")).refs
+                    $(Symbol("pool_$(k)")) = $(Symbol("A_$(k)")).pool
                 end : nothing
             for k = 1:narrays]...))
 
@@ -134,16 +134,16 @@ function gen_broadcast_dataarray(nd::Int, arrtype::@compat(Tuple{Vararg{DataType
                 # pre
                 d->($(Expr(:block, [
                     arrtype[k] == DataArray ? quote
-                        $(symbol("state_$(k)_")){d-1} = $(symbol("state_$(k)_d"));
-                        $(symbol("j_$(k)_d")) = $(symbol("skip_$(k)_d")) ? 1 : i_d
+                        $(Symbol("state_$(k)_")){d-1} = $(Symbol("state_$(k)_d"));
+                        $(Symbol("j_$(k)_d")) = $(Symbol("skip_$(k)_d")) ? 1 : i_d
                     end : quote
-                        $(symbol("j_$(k)_d")) = size($(symbol("A_$(k)")), d) == 1 ? 1 : i_d
+                        $(Symbol("j_$(k)_d")) = size($(Symbol("A_$(k)")), d) == 1 ? 1 : i_d
                     end
                 for k = 1:narrays]...))),
 
                 # post
                 d->($(Expr(:block, [quote
-                    $(symbol("skip_$(k)_d")) || ($(symbol("state_$(k)_d")) = $(symbol("state_$(k)_0")))
+                    $(Symbol("skip_$(k)_d")) || ($(Symbol("state_$(k)_d")) = $(Symbol("state_$(k)_0")))
                 end for k in dataarrays]...))),
 
                 # body
@@ -151,23 +151,23 @@ function gen_broadcast_dataarray(nd::Int, arrtype::@compat(Tuple{Vararg{DataType
                     # Advance iterators for DataArray and determine NA status
                     $(Expr(:block, [
                         arrtype[k] == DataArray ? quote
-                            @inbounds $(symbol("isna_$(k)")) = Base.unsafe_bitgetindex($(symbol("na_$(k)")), $(symbol("state_$(k)_0")))
+                            @inbounds $(Symbol("isna_$(k)")) = Base.unsafe_bitgetindex($(Symbol("na_$(k)")), $(Symbol("state_$(k)_0")))
                         end : arrtype[k] == PooledDataArray ? quote
-                            @inbounds $(symbol("r_$(k)")) = @nref $nd $(symbol("refs_$(k)")) d->$(symbol("j_$(k)_d"))
-                            $(symbol("isna_$(k)")) = $(symbol("r_$(k)")) == 0
+                            @inbounds $(Symbol("r_$(k)")) = @nref $nd $(Symbol("refs_$(k)")) d->$(Symbol("j_$(k)_d"))
+                            $(Symbol("isna_$(k)")) = $(Symbol("r_$(k)")) == 0
                         end : nothing
                     for k = 1:narrays]...))
 
                     # Extract values for ordinary AbstractArrays
                     $(Expr(:block, [
-                        :(@inbounds $(symbol("v_$(k)")) = @nref $nd $(symbol("A_$(k)")) d->$(symbol("j_$(k)_d")))
+                        :(@inbounds $(Symbol("v_$(k)")) = @nref $nd $(Symbol("A_$(k)")) d->$(Symbol("j_$(k)_d")))
                     for k = find([arrtype...] .== AbstractArray)]...))
 
                     # Compute and store return value
                     $(gen_na_conds(F, nd, arrtype, outtype))
 
                     # Increment state
-                    $(Expr(:block, [:($(symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
+                    $(Expr(:block, [:($(Symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
                     $(if outtype == DataArray
                         :(ind += 1)
                     end)
@@ -207,9 +207,7 @@ for bsig in (DataArray, PooledDataArray), asig in ((@compat Union{Array,BitArray
             func(B, As...)
             B
         end
-        # ambiguity
-        Base.map!(f::Base.Callable, B::$bsig, r::Range) =
-            invoke(Base.map!, (Base.Callable, $bsig, $asig), f, B, r)
+
         function Base.broadcast!(f::Function, B::$bsig, As::$asig...)
             nd = ndims(B)
             length(As) <= 8 || throw(ArgumentError("too many arguments"))
@@ -254,15 +252,15 @@ macro da_broadcast_vararg(func)
     defs = Any[]
     for n = 1:4, aa = 0:n-1
         def = deepcopy(func)
-        rep = Any[symbol("A_$(i)") for i = 1:n]
+        rep = Any[Symbol("A_$(i)") for i = 1:n]
         push!(rep, va)
         exreplace!(def.args[2], va, rep)
         rep = cell(n+1)
         for i = 1:aa
-            rep[i] = Expr(:(::), symbol("A_$i"), AbstractArray)
+            rep[i] = Expr(:(::), Symbol("A_$i"), AbstractArray)
         end
         for i = aa+1:n
-            rep[i] = Expr(:(::), symbol("A_$i"), (@compat Union{DataArray, PooledDataArray}))
+            rep[i] = Expr(:(::), Symbol("A_$i"), (@compat Union{DataArray, PooledDataArray}))
         end
         rep[end] = Expr(:..., Expr(:(::), va.args[1], AbstractArray))
         exreplace!(def.args[1], va, rep)
@@ -277,12 +275,13 @@ macro da_broadcast_binary(func)
        length(func.args[1].args) != 3
         throw(ArgumentError("@da_broadcast_binary may only be applied to two-argument functions"))
     end
-    (f, A, B) = func.args[1].args
+    (ff, A, B) = func.args[1].args
+    f = esc(ff)
     body = func.args[2]
     quote
-        $f($A::(@compat Union{DataArray, PooledDataArray}), $B::(@compat Union{DataArray, PooledDataArray})) = $(body)
-        $f($A::(@compat Union{DataArray, PooledDataArray}), $B::AbstractArray) = $(body)
-        $f($A::AbstractArray, $B::(@compat Union{DataArray, PooledDataArray})) = $(body)
+        ($f)($A::(@compat Union{DataArray, PooledDataArray}), $B::(@compat Union{DataArray, PooledDataArray})) = $(body)
+        ($f)($A::(@compat Union{DataArray, PooledDataArray}), $B::AbstractArray) = $(body)
+        ($f)($A::AbstractArray, $B::(@compat Union{DataArray, PooledDataArray})) = $(body)
     end
 end
 
@@ -290,34 +289,34 @@ end
 @da_broadcast_vararg Base.broadcast(f::Function, As...) = databroadcast(f, As...)
 
 # Definitions for operators,
-Base.(:(.*))(A::BitArray, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(*, A, B)
-Base.(:(.*))(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::BitArray) = databroadcast(*, A, B)
-@da_broadcast_vararg Base.(:(.*))(As...) = databroadcast(*, As...)
-@da_broadcast_binary Base.(:(.%))(A, B) = databroadcast(%, A, B)
-@da_broadcast_vararg Base.(:(.+))(As...) = broadcast!(+, DataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
-@da_broadcast_binary Base.(:(.-))(A, B) = broadcast!(-, DataArray(_type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
-@da_broadcast_binary Base.(:(./))(A, B) = broadcast!(/, DataArray(_type_rdiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
-@da_broadcast_binary Base.(:(.\))(A, B) = broadcast!(\, DataArray(_type_ldiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
-Base.(:(.^))(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
-Base.(:(.^))(A::BitArray, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
-Base.(:(.^))(A::AbstractArray{Bool}, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
-Base.(:(.^))(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::BitArray) = databroadcast(>=, A, B)
-Base.(:(.^))(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::AbstractArray{Bool}) = databroadcast(>=, A, B)
-@da_broadcast_binary Base.(:(.^))(A, B) = broadcast!(^, DataArray(_type_pow(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+(.*)(A::BitArray, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(*, A, B)
+(.*)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::BitArray) = databroadcast(*, A, B)
+@da_broadcast_vararg (.*)(As...) = databroadcast(*, As...)
+@da_broadcast_binary (.%)(A, B) = databroadcast(%, A, B)
+@da_broadcast_vararg (.+)(As...) = broadcast!(+, DataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
+@da_broadcast_binary (.-)(A, B) = broadcast!(-, DataArray(_type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
+@da_broadcast_binary (./)(A, B) = broadcast!(/, DataArray(_type_rdiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+@da_broadcast_binary (.\)(A, B) = broadcast!(\, DataArray(_type_ldiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+(.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
+(.^)(A::BitArray, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
+(.^)(A::AbstractArray{Bool}, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
+(.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::BitArray) = databroadcast(>=, A, B)
+(.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::AbstractArray{Bool}) = databroadcast(>=, A, B)
+@da_broadcast_binary (.^)(A, B) = broadcast!(^, DataArray(_type_pow(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
 
 # XXX is a PDA the right return type for these?
 Base.broadcast(f::Function, As::PooledDataArray...) = pdabroadcast(f, As...)
-Base.(:(.*))(As::PooledDataArray...) = pdabroadcast(*, As...)
-Base.(:(.%))(A::PooledDataArray, B::PooledDataArray) = pdabroadcast(%, A, B)
-Base.(:(.+))(As::PooledDataArray...) = broadcast!(+, PooledDataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
-Base.(:(.-))(A::PooledDataArray, B::PooledDataArray) =
+(.*)(As::PooledDataArray...) = pdabroadcast(*, As...)
+(.%)(A::PooledDataArray, B::PooledDataArray) = pdabroadcast(%, A, B)
+(.+)(As::PooledDataArray...) = broadcast!(+, PooledDataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
+(.-)(A::PooledDataArray, B::PooledDataArray) =
     broadcast!(-, PooledDataArray(_type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
-Base.(:(./))(A::PooledDataArray, B::PooledDataArray) =
+(./)(A::PooledDataArray, B::PooledDataArray) =
     broadcast!(/, PooledDataArray(_type_rdiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
-Base.(:(.\))(A::PooledDataArray, B::PooledDataArray) =
+(.\)(A::PooledDataArray, B::PooledDataArray) =
     broadcast!(\, PooledDataArray(_type_ldiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
-Base.(:(.^))(A::PooledDataArray{Bool}, B::PooledDataArray{Bool}) = databroadcast(>=, A, B)
-Base.(:(.^))(A::PooledDataArray, B::PooledDataArray) =
+(.^)(A::PooledDataArray{Bool}, B::PooledDataArray{Bool}) = databroadcast(>=, A, B)
+(.^)(A::PooledDataArray, B::PooledDataArray) =
     broadcast!(^, PooledDataArray(_type_pow(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
 
 for (sf, vf) in zip(scalar_comparison_operators, array_comparison_operators)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -191,7 +191,7 @@ datype_int(A_1::DataArray, As...) = (@compat(UInt64(1)) | (datype_int(As...) << 
 datype_int(A_1, As...) = (datype_int(As...) << 2)
 datype_int() = @compat UInt64(0)
 
-for bsig in (DataArray, PooledDataArray), asig in ((@compat Union{Array,BitArray,Number}), Any)
+for bsig in (DataArray, PooledDataArray), asig in (Union{Array,BitArray,Number},DataArray, PooledDataArray)
     @eval let cache = Dict{Function,Dict{UInt64,Dict{Int,Function}}}()
         function Base.map!(f::Base.Callable, B::$bsig, As::$asig...)
             nd = ndims(B)

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -81,7 +81,7 @@ end
 #'
 #' da = DataArray([1, 2, 3], [false, false, true])
 function DataArray(d::Array, m::Array{Bool}) # -> DataArray{T}
-    return DataArray(d, bitpack(m))
+    return DataArray(d, BitArray(m))
 end
 
 #' @description

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -447,9 +447,9 @@ isna(da::DataArray) = copy(da.na) # -> BitArray
 #' a = @data([1, 2, 3])
 #' isna(a, 1)
 #' isna(a, 1:2)
-isna(da::DataArray, I::Any) = getindex(da.na, I)
+isna(da::DataArray, I::Real) = getindex(da.na, I)
 
-@nsplat N function isna(da::DataArray, I::NTuple{N,Any}...)
+@nsplat N function isna(da::DataArray, I::NTuple{N,Real}...)
     getindex(da.na, I...)
 end
 

--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -169,16 +169,12 @@ function Base.append!(da::AbstractDataVector, items::AbstractVector)
     da
 end
 
-m = VERSION < v"0.4.0-dev+2014" ? :Compat : :Base
-@eval begin
-    function $(m).sizehint!(da::DataVector, newsz::Integer)
-        sizehint!(da.data, newsz)
-        sizehint!(da.na, newsz)
-    end
-
-    $(m).sizehint!(pda::PooledDataVector, newsz::Integer) = sizehint!(pda.refs, newsz)
+function Base.sizehint!(da::DataVector, newsz::Integer)
+    sizehint!(da.data, newsz)
+    sizehint!(da.na, newsz)
 end
-m == :Compat && export sizehint!
+Base.sizehint!(pda::PooledDataVector, newsz::Integer) =
+    sizehint!(pda.refs, newsz)
 
 function Base.sizehint(da::DataVector, newsz::Integer)
     sizehint(da.data, newsz)

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -49,7 +49,7 @@ function cut{S, T}(x::AbstractVector{S}, breaks::Vector{T})
     n = length(breaks)
     from = map(x -> sprint(showcompact, x), breaks[1:(n - 1)])
     to = map(x -> sprint(showcompact, x), breaks[2:n])
-    pool = Array(ASCIIString, n - 1)
+    pool = Array(String, n - 1)
     if breaks[1] == min_x
         pool[1] = string("[", from[1], ",", to[1], "]")
     else
@@ -79,7 +79,7 @@ function rep{T <: Integer}(x::AbstractVector, lengths::AbstractVector{T})
     return res
 end
 
-function rep(x::AbstractVector, times::Integer = 1, each::Integer = 1)
+function rep(x::AbstractVector, times::Integer, each::Integer = 1)
     res = similar(x, each * times * length(x))
     i = 1
     for jdx in 1:times
@@ -98,4 +98,4 @@ function rep(x::AbstractVector; times::Integer = 1, each::Integer = 1)
     rep(x, times, each)
 end
 
-rep(x::Any, times::Integer) = fill(x, times)
+rep(x::Number, times::Integer) = fill(x, times)

--- a/src/natype.jl
+++ b/src/natype.jl
@@ -22,7 +22,7 @@ const NA = NAtype()
 Base.show(io::IO, x::NAtype) = print(io, "NA")
 
 type NAException <: Exception
-    msg::UTF8String
+    msg::String
 end
 NAException() = NAException("NA found")
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,12 +1,8 @@
-const unary_operators = [:(Base.(:+)),
-                         :(Base.(:-)),
-                         :(Base.(:!)),
-                         :(Base.(:*))]
+const unary_operators = [:+, :-, :!, :*]
 
-const numeric_unary_operators = [:(Base.(:+)),
-                                 :(Base.(:-))]
+const numeric_unary_operators = [:+, :-]
 
-const logical_unary_operators = [:(Base.(:!))]
+const logical_unary_operators = [:!]
 
 const elementary_functions = [:(Base.abs),
                               :(Base.abs2),
@@ -50,102 +46,44 @@ const two_argument_elementary_functions = [:(Base.round),
 
 const special_comparison_operators = [:(Base.isless)]
 
-const comparison_operators = [:(Base.(:(==))),
-                              :(Base.(:(.==))),
-                              :(Base.(:(!=))),
-                              :(Base.(:(.!=))),
-                              :(Base.(:(>))),
-                              :(Base.(:(.>))),
-                              :(Base.(:(>=))),
-                              :(Base.(:(.>=))),
-                              :(Base.(:(<))),
-                              :(Base.(:(.<))),
-                              :(Base.(:(<=))),
-                              :(Base.(:(.<=)))]
+const comparison_operators = [:(==),:(.==),:(!=),:(.!=),:(>),:(.>),:(>=),:(.>=),:(<),:(.<),:(<=),:(.<=)]
 
-const scalar_comparison_operators = [:(Base.(:(==))),
-                                     :(Base.(:(!=))),
-                                     :(Base.(:(>))),
-                                     :(Base.(:(>=))),
-                                     :(Base.(:(<))),
-                                     :(Base.(:(<=)))]
+const scalar_comparison_operators = [:(==),:(!=),:(>),:(>=),:(<),:(<=)]
 
-const array_comparison_operators = [:(Base.(:(.==))),
-                                    :(Base.(:(.!=))),
-                                    :(Base.(:(.>))),
-                                    :(Base.(:(.>=))),
-                                    :(Base.(:(.<))),
-                                    :(Base.(:(.<=)))]
+const array_comparison_operators = [:(.==),:(.!=),:(.>),:(.>=),:(.<),:(.<=)]
 
-const vectorized_comparison_operators = [:(Base.(:(.==))),
-                                         :(Base.(:(==))),
-                                         :(Base.(:(.!=))),
-                                         :(Base.(:(!=))),
-                                         :(Base.(:(.>))),
-                                         :(Base.(:(>))),
-                                         :(Base.(:(.>=))),
-                                         :(Base.(:(>=))),
-                                         :(Base.(:(.<))),
-                                         :(Base.(:(<))),
-                                         :(Base.(:(.<=))),
-                                         :(Base.(:(<=)))]
+const vectorized_comparison_operators = [:(.==),:(==),:(.!=),:(!=),:(.>),:(>),:(.>=),:(>=),:(.<),:(<),:(.<=),:(<=)]
 
-const binary_operators = [:(Base.(:+)),
-                          :(Base.(:.+)),
-                          :(Base.(:-)),
-                          :(Base.(:.-)),
-                          :(Base.(:*)),
-                          :(Base.(:.*)),
-                          :(Base.(:/)),
-                          :(Base.(:./)),
-                          :(Base.(:.^)),
+const binary_operators = [:(+),:(.+),:(-),:(.-),:(*),:(.*),:(/),:(./),:(.^),
                           :(Base.div),
                           :(Base.mod),
                           :(Base.fld),
                           :(Base.rem)]
 
-const induced_binary_operators = [:(Base.(:^))]
+const induced_binary_operators = [(:^)]
 
-const arithmetic_operators = [:(Base.(:+)),
-                              :(Base.(:.+)),
-                              :(Base.(:-)),
-                              :(Base.(:.-)),
-                              :(Base.(:*)),
-                              :(Base.(:.*)),
-                              :(Base.(:/)),
-                              :(Base.(:./)),
-                              :(Base.(:.^)),
+const arithmetic_operators = [:(+),:(.+),:(-),:(.-),:(*),:(.*),:(/),:(./),:(.^),
                               :(Base.div),
                               :(Base.mod),
                               :(Base.fld),
                               :(Base.rem)]
 
-const induced_arithmetic_operators = [:(Base.(:^))]
+const induced_arithmetic_operators = [:(^)]
 
 const biscalar_operators = [:(Base.maximum),
                             :(Base.minimum)]
 
-const scalar_arithmetic_operators = [:(Base.(:+)),
-                                     :(Base.(:-)),
-                                     :(Base.(:*)),
-                                     :(Base.(:/)),
+const scalar_arithmetic_operators = [:(+),:(-),:(*),:(/),
                                      :(Base.div),
                                      :(Base.mod),
                                      :(Base.fld),
                                      :(Base.rem)]
 
-const induced_scalar_arithmetic_operators = [:(Base.(:^))]
+const induced_scalar_arithmetic_operators = [:(^)]
 
-const array_arithmetic_operators = [:(Base.(:+)),
-                                    :(Base.(:.+)),
-                                    :(Base.(:-)),
-                                    :(Base.(:.-)),
-                                    :(Base.(:.*)),
-                                    :(Base.(:.^))]
+const array_arithmetic_operators = [:(+),:(.+),:(-),:(.-),:(.*),:(.^)]
 
-const bit_operators = [:(Base.(:&)),
-                       :(Base.(:|)),
-                       :(Base.(:$))]
+const bit_operators = [:(&),:(|),:($)]
 
 const unary_vector_operators = [:(Base.median),
                                 :(StatsBase.mad),
@@ -307,7 +245,7 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                 if swappable
                     # For /, Array/Number is valid but not Number/Array
                     # All other operators should be swappable
-                    map!(x->Expr(:macrocall, symbol("@swappable"), x, scalarfunc), fns)
+                    map!(x->Expr(:macrocall, Symbol("@swappable"), x, scalarfunc), fns)
                 end
                 Expr(:block, fns...)
             end
@@ -370,9 +308,9 @@ for f in unary_operators
 end
 
 # Unary operators, DataArrays.
-@dataarray_unary Base.(:(-)) Bool Int
-@dataarray_unary Base.(:(-)) Any T
-@dataarray_unary Base.(:(!)) Bool T
+@dataarray_unary(-, Bool, Int)
+@dataarray_unary(-, Any, T)
+@dataarray_unary(!, Bool, T)
 
 # Treat ctranspose and * in a special way
 for (f, elf) in ((:(Base.ctranspose), :conj), (:(Base.transpose), :identity))
@@ -407,7 +345,7 @@ end
 # But we're getting 10x R while maintaining NA's
 for (adata, bdata) in ((true, false), (false, true), (true, true))
     @eval begin
-        function Base.(:*)(a::$(adata ? :((@compat Union{DataVector, DataMatrix})) : :((@compat Union{Vector, Matrix}))),
+        function (*)(a::$(adata ? :((@compat Union{DataVector, DataMatrix})) : :((@compat Union{Vector, Matrix}))),
                            b::$(bdata ? :((@compat Union{DataVector, DataMatrix})) : :(@compat Union{Vector, Matrix})))
             c = $(adata ? :(a.data) : :a) * $(bdata ? :(b.data) : :b)
             res = DataArray(c, falses(size(c)))
@@ -513,14 +451,14 @@ end
 # Bit operators
 #
 
-@swappable Base.(:&)(a::NAtype, b::Bool) = b ? NA : false
-@swappable Base.(:|)(a::NAtype, b::Bool) = b ? true : NA
-@swappable Base.(:$)(a::NAtype, b::Bool) = NA
+@swappable (&)(a::NAtype, b::Bool) = b ? NA : false
+@swappable (|)(a::NAtype, b::Bool) = b ? true : NA
+@swappable ($)(a::NAtype, b::Bool) = NA
 
 # To avoid ambiguity warning
-@swappable Base.(:|)(a::NAtype, b::Function) = NA
+@swappable (|)(a::NAtype, b::Function) = NA
 
-for f in (:(Base.(:&)), :(Base.(:|)), :(Base.(:$)))
+for f in (:(&), :(|), :($))
     @eval begin
         # Scalar with NA
         ($f)(::NAtype, ::NAtype) = NA
@@ -529,20 +467,20 @@ for f in (:(Base.(:&)), :(Base.(:|)), :(Base.(:$)))
 end
 
 # DataArray with DataArray
-Base.(:&)(a::DataArray{Bool}, b::DataArray{Bool}) =
+(&)(a::DataArray{Bool}, b::DataArray{Bool}) =
     DataArray(a.data & b.data, (a.na & b.na) | (a.na & b.data) | (b.na & a.data))
-Base.(:|)(a::DataArray{Bool}, b::DataArray{Bool}) =
+(|)(a::DataArray{Bool}, b::DataArray{Bool}) =
     DataArray(a.data | b.data, (a.na & b.na) | (a.na & !b.data) | (b.na & !a.data))
-Base.(:$)(a::DataArray{Bool}, b::DataArray{Bool}) =
+($)(a::DataArray{Bool}, b::DataArray{Bool}) =
     DataArray(a.data $ b.data, a.na | b.na)
 
 # DataArray with non-DataArray
 # Need explicit definition for BitArray to avoid ambiguity
 for t in (:(BitArray), :(Range{Bool}), :((@compat Union{AbstractArray{Bool}, Bool})))
     @eval begin
-        @swappable Base.(:&)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data & b), a.na & b)
-        @swappable Base.(:|)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data | b), a.na & !b)
-        @swappable Base.(:$)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data $ b), copy(a.na))
+        @swappable (&)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data & b), a.na & b)
+        @swappable (|)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data | b), a.na & !b)
+        @swappable ($)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data $ b), copy(a.na))
     end
 end
 
@@ -572,16 +510,16 @@ function Base.isequal(a::DataArray, b::DataArray)
 end
 
 # ambiguity
-@swappable Base.(:(==))(a::DataArray{Bool}, b::BitArray) =
+@swappable (==)(a::DataArray{Bool}, b::BitArray) =
     invoke(==, (DataArray, AbstractArray), a, b)
-@swappable Base.(:(==))(a::DataArray, b::BitArray) =
+@swappable (==)(a::DataArray, b::BitArray) =
     invoke(==, (DataArray, AbstractArray), a, b)
-@swappable Base.(:(==))(a::AbstractDataArray{Bool}, b::BitArray) =
+@swappable (==)(a::AbstractDataArray{Bool}, b::BitArray) =
     invoke(==, (DataArray, AbstractArray), a, b)
-@swappable Base.(:(==))(a::AbstractDataArray, b::BitArray) =
+@swappable (==)(a::AbstractDataArray, b::BitArray) =
     invoke(==, (DataArray, AbstractArray), a, b)
 
-function Base.(:(==))(a::DataArray, b::DataArray)
+function (==)(a::DataArray, b::DataArray)
     size(a) == size(b) || return false
     adata = a.data
     bdata = b.data
@@ -598,10 +536,10 @@ function Base.(:(==))(a::DataArray, b::DataArray)
 end
 
 # ambiguity
-@swappable Base.(:(==))(a::DataArray, b::AbstractDataArray) =
+@swappable (==)(a::DataArray, b::AbstractDataArray) =
     invoke(==, (AbstractDataArray, AbstractDataArray), a, b)
 
-@swappable function Base.(:(==))(a::DataArray, b::AbstractArray)
+@swappable function (==)(a::DataArray, b::AbstractArray)
     size(a) == size(b) || return false
     adata = a.data
     has_na = false
@@ -615,7 +553,7 @@ end
     has_na ? NA : true
 end
 
-function Base.(:(==))(a::AbstractDataArray, b::AbstractDataArray)
+function (==)(a::AbstractDataArray, b::AbstractDataArray)
     size(a) == size(b) || return false
     has_na = false
     for i = 1:length(a)
@@ -628,7 +566,7 @@ function Base.(:(==))(a::AbstractDataArray, b::AbstractDataArray)
     has_na ? NA : true
 end
 
-@swappable function Base.(:(==))(a::AbstractDataArray, b::AbstractArray)
+@swappable function (==)(a::AbstractDataArray, b::AbstractArray)
     size(a) == size(b) || return false
     has_na = false
     for i = 1:length(a)
@@ -642,7 +580,7 @@ end
 end
 
 # ambiguity
-@swappable Base.(:(==))(::NAtype, ::WeakRef) = NA
+@swappable (==)(::NAtype, ::WeakRef) = NA
 
 for (sf,vf) in zip(scalar_comparison_operators, array_comparison_operators)
     @eval begin
@@ -665,11 +603,11 @@ end
 #
 
 # Necessary to avoid ambiguity warnings
-Base.(:.^)(::Irrational{:e}, B::DataArray) = exp(B)
-Base.(:.^)(::Irrational{:e}, B::AbstractDataArray) = exp(B)
+(.^)(::Irrational{:e}, B::DataArray) = exp(B)
+(.^)(::Irrational{:e}, B::AbstractDataArray) = exp(B)
 
-for f in (:(Base.(:+)), :(Base.(:.+)), :(Base.(:-)), :(Base.(:.-)),
-          :(Base.(:*)), :(Base.(:.*)), :(Base.(:.^)), :(Base.div),
+for f in (:(+), :(.+), :(-), :(.-),
+          :(*), :(.*), :(.^), :(Base.div),
           :(Base.mod), :(Base.fld), :(Base.rem), :(Base.min),
           :(Base.max))
     @eval begin
@@ -683,8 +621,8 @@ end
 # warnings...
 if isdefined(Base, :UniformScaling)
 
-function Base.(:+){TA,TJ}(A::DataArray{TA,2},J::UniformScaling{TJ})
-    n = Base.LinAlg.chksquare(A)
+function (+){TA,TJ}(A::DataArray{TA,2},J::UniformScaling{TJ})
+    n = Compat.LinAlg.checksquare(A)
     B = similar(A,promote_type(TA,TJ))
     copy!(B,A)
     @inbounds for i = 1:n
@@ -694,10 +632,10 @@ function Base.(:+){TA,TJ}(A::DataArray{TA,2},J::UniformScaling{TJ})
     end
     B
 end
-Base.(:+){TA}(J::UniformScaling,A::DataArray{TA,2}) = A + J
+(+){TA}(J::UniformScaling,A::DataArray{TA,2}) = A + J
 
-function Base.(:-){TA,TJ<:Number}(A::DataArray{TA,2},J::UniformScaling{TJ})
-    n = Base.LinAlg.chksquare(A)
+function (-){TA,TJ<:Number}(A::DataArray{TA,2},J::UniformScaling{TJ})
+    n = Compat.LinAlg.checksquare(A)
     B = similar(A,promote_type(TA,TJ))
     copy!(B,A)
     @inbounds for i = 1:n
@@ -707,8 +645,8 @@ function Base.(:-){TA,TJ<:Number}(A::DataArray{TA,2},J::UniformScaling{TJ})
     end
     B
 end
-function Base.(:-){TA,TJ<:Number}(J::UniformScaling{TJ},A::DataArray{TA,2})
-    n = Base.LinAlg.chksquare(A)
+function (-){TA,TJ<:Number}(J::UniformScaling{TJ},A::DataArray{TA,2})
+    n = Compat.LinAlg.checksquare(A)
     B = -A
     @inbounds for i = 1:n
         if !B.na[i,i]
@@ -718,37 +656,37 @@ function Base.(:-){TA,TJ<:Number}(J::UniformScaling{TJ},A::DataArray{TA,2})
     B
 end
 
-Base.(:+)(A::DataArray{Bool,2},J::UniformScaling{Bool}) =
+(+)(A::DataArray{Bool,2},J::UniformScaling{Bool}) =
     invoke(+, (AbstractArray{Bool,2}, UniformScaling{Bool}), A, J)
-Base.(:+)(J::UniformScaling{Bool},A::DataArray{Bool,2}) =
+(+)(J::UniformScaling{Bool},A::DataArray{Bool,2}) =
     invoke(+, (UniformScaling{Bool}, AbstractArray{Bool,2}), J, A)
-Base.(:-)(A::DataArray{Bool,2},J::UniformScaling{Bool}) =
+(-)(A::DataArray{Bool,2},J::UniformScaling{Bool}) =
     invoke(-, (AbstractArray{Bool,2}, UniformScaling{Bool}), A, J)
-Base.(:-)(J::UniformScaling{Bool},A::DataArray{Bool,2}) =
+(-)(J::UniformScaling{Bool},A::DataArray{Bool,2}) =
     invoke(-, (UniformScaling{Bool}, AbstractArray{Bool,2}), J, A)
 
-Base.(:+){TA,TJ}(A::AbstractDataArray{TA,2},J::UniformScaling{TJ}) =
+(+){TA,TJ}(A::AbstractDataArray{TA,2},J::UniformScaling{TJ}) =
     invoke(+, (AbstractArray{TA,2}, UniformScaling{TJ}), A, J)
-Base.(:+){TA}(J::UniformScaling,A::AbstractDataArray{TA,2}) =
+(+){TA}(J::UniformScaling,A::AbstractDataArray{TA,2}) =
     invoke(+, (UniformScaling, AbstractArray{TA,2}), J, A)
-Base.(:-){TA,TJ<:Number}(A::AbstractDataArray{TA,2},J::UniformScaling{TJ}) =
+(-){TA,TJ<:Number}(A::AbstractDataArray{TA,2},J::UniformScaling{TJ}) =
     invoke(-, (AbstractArray{TA,2}, UniformScaling{TJ}), A, J)
-Base.(:-){TA,TJ<:Number}(J::UniformScaling{TJ},A::AbstractDataArray{TA,2}) =
+(-){TA,TJ<:Number}(J::UniformScaling{TJ},A::AbstractDataArray{TA,2}) =
     invoke(-, (UniformScaling{TJ}, AbstractArray{TA,2}), J, A)
 
-Base.(:+)(A::AbstractDataArray{Bool,2},J::UniformScaling{Bool}) =
+(+)(A::AbstractDataArray{Bool,2},J::UniformScaling{Bool}) =
     invoke(+, (AbstractArray{Bool,2}, UniformScaling{Bool}), A, J)
-Base.(:+)(J::UniformScaling{Bool},A::AbstractDataArray{Bool,2}) =
+(+)(J::UniformScaling{Bool},A::AbstractDataArray{Bool,2}) =
     invoke(+, (UniformScaling{Bool}, AbstractArray{Bool,2}), J, A)
-Base.(:-)(A::AbstractDataArray{Bool,2},J::UniformScaling{Bool}) =
+(-)(A::AbstractDataArray{Bool,2},J::UniformScaling{Bool}) =
     invoke(-, (AbstractArray{Bool,2}, UniformScaling{Bool}), A, J)
-Base.(:-)(J::UniformScaling{Bool},A::AbstractDataArray{Bool,2}) =
+(-)(J::UniformScaling{Bool},A::AbstractDataArray{Bool,2}) =
     invoke(-, (UniformScaling{Bool}, AbstractArray{Bool,2}), J, A)
 
 end # if isdefined(Base, :UniformScaling)
 
-for f in (:(Base.(:.+)), :(Base.(:.-)), :(Base.(:*)), :(Base.(:.*)),
-          :(Base.(:.^)), :(Base.div), :(Base.mod), :(Base.fld), :(Base.rem))
+for f in (:(.+), :(.-), :(*), :(.*),
+          :(.^), :(Base.div), :(Base.mod), :(Base.fld), :(Base.rem))
     @eval begin
         # Array with NA
         @swappable $(f){T,N}(::NAtype, b::AbstractArray{T,N}) =
@@ -759,44 +697,44 @@ for f in (:(Base.(:.+)), :(Base.(:.-)), :(Base.(:*)), :(Base.(:.*)),
     end
 end
 
-for f in (:(Base.(:+)), :(Base.(:-)))
+for f in (:(+), :(-))
     # Array with NA
     @eval @swappable $(f){T,N}(::NAtype, b::AbstractArray{T,N}) =
         DataArray(Array(T, size(b)), trues(size(b)))
 end
 
-Base.(:^)(::NAtype, ::NAtype) = NA
-Base.(:^)(a, ::NAtype) = NA
-Base.(:^)(::NAtype, ::Integer) = NA
-Base.(:^)(::NAtype, ::Number) = NA
+(^)(::NAtype, ::NAtype) = NA
+(^)(a, ::NAtype) = NA
+(^)(::NAtype, ::Integer) = NA
+(^)(::NAtype, ::Number) = NA
 
-for (vf, sf) in ((:(Base.(:+)), :(Base.(:+))),
-                 (:(Base.(:-)), :(Base.(:-))))
+for (vf, sf) in ((:(+), :(+)),
+                 (:(-), :(-)))
     @eval begin
         # Necessary to avoid ambiguity warnings
-        @swappable ($vf)(A::BitArray, B::AbstractDataArray{Bool}) = ($vf)(bitunpack(A), B)
-        @swappable ($vf)(A::BitArray, B::DataArray{Bool}) = ($vf)(bitunpack(A), B)
+        @swappable ($vf)(A::BitArray, B::AbstractDataArray{Bool}) = ($vf)(Array(A), B)
+        @swappable ($vf)(A::BitArray, B::DataArray{Bool}) = ($vf)(Array(A), B)
 
         @dataarray_binary_array $vf $sf promote_type(eltype(a), eltype(b))
     end
 end
 
 # / and ./ are defined separately since they promote to floating point
-for f in ((:(Base.(:/)), :(Base.(:./))))
+for f in (:(/), :(./))
     @eval begin
         ($f)(::NAtype, ::NAtype) = NA
         @swappable ($f)(d::NAtype, x::Number) = NA
     end
 end
 
-Base.(:/){T,N}(b::AbstractArray{T,N}, ::NAtype) =
+(/){T,N}(b::AbstractArray{T,N}, ::NAtype) =
     DataArray(Array(T, size(b)), trues(size(b)))
-@dataarray_binary_scalar Base.(:/) Base.(:/) eltype(a) <: AbstractFloat || typeof(b) <: AbstractFloat ?
-                                      promote_type(eltype(a), typeof(b)) : Float64 false
-@swappable Base.(:./){T,N}(::NAtype, b::AbstractArray{T,N}) =
+@dataarray_binary_scalar(/, /, eltype(a) <: AbstractFloat || typeof(b) <: AbstractFloat ?
+                                      promote_type(eltype(a), typeof(b)) : Float64, false)
+@swappable (./){T,N}(::NAtype, b::AbstractArray{T,N}) =
     DataArray(Array(T, size(b)), trues(size(b)))
-@dataarray_binary_scalar Base.(:./) Base.(:/) eltype(a) <: AbstractFloat || typeof(b) <: AbstractFloat ?
-                                      promote_type(eltype(a), typeof(b)) : Float64 true
+@dataarray_binary_scalar(./, /, eltype(a) <: AbstractFloat || typeof(b) <: AbstractFloat ?
+                                      promote_type(eltype(a), typeof(b)) : Float64, true)
 
 for f in biscalar_operators
     @eval begin
@@ -849,8 +787,8 @@ end
 for f in (:(Base.minimum), :(Base.maximum), :(Base.prod), :(Base.sum),
           :(Base.mean), :(Base.median), :(Base.std), :(Base.var),
           :(Base.norm))
-    colf = symbol("col$(f)s")
-    rowf = symbol("row$(f)s")
+    colf = Symbol("col$(f)s")
+    rowf = Symbol("row$(f)s")
     @eval begin
         function ($colf)(dm::AbstractDataMatrix)
             n, p = nrow(dm), ncol(dm)
@@ -995,7 +933,7 @@ end
 ## inverse run-length encoding
 function inverse_rle{T, I <: Integer}(values::AbstractVector{T},
                                       lengths::Vector{I})
-    total_n = sum(lengths)
+    total_n = Int(sum(lengths))
     pos = 0
     res = similar(values, total_n)
     n = length(values)

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -113,8 +113,8 @@ PooledDataArray{R<:Integer}(t::Type, r::Type{R}) = PooledDataArray(similar(Array
 # Convert a BitArray to an Array{Bool} (m = missingness)
 # For some reason an additional method is needed but even that doesn't work
 # For a BitArray a refs type of UInt8 will always be sufficient as the size of the pool is 0, 1 or 2
-PooledDataArray{N}(d::BitArray{N}) = PooledDataArray(bitunpack(d), falses(size(d)), UInt8)
-PooledDataArray{N}(d::BitArray{N}, m::AbstractArray{Bool, N}) = PooledDataArray(bitunpack(d), m, UInt8)
+PooledDataArray{N}(d::BitArray{N}) = PooledDataArray(Array(d), falses(size(d)), UInt8)
+PooledDataArray{N}(d::BitArray{N}, m::AbstractArray{Bool, N}) = PooledDataArray(Array(d), m, UInt8)
 
 # Convert a DataArray to a PooledDataArray
 PooledDataArray{T,R<:Integer}(da::DataArray{T},
@@ -598,7 +598,6 @@ type FastPerm{O<:Base.Sort.Ordering,V<:AbstractVector} <: Base.Sort.Ordering
     ord::O
     vec::V
 end
-FastPerm{O<:Base.Sort.Ordering,V<:AbstractVector}(o::O,v::V) = FastPerm{O,V}(o,v)
 Base.sortperm{V}(x::AbstractVector, a::Base.Sort.Algorithm, o::FastPerm{Base.Sort.ForwardOrdering,V}) = x[sortperm(o.vec)]
 Base.sortperm{V}(x::AbstractVector, a::Base.Sort.Algorithm, o::FastPerm{Base.Sort.ReverseOrdering,V}) = x[reverse(sortperm(o.vec))]
 Perm{O<:Base.Sort.Ordering}(o::O, v::PooledDataVector) = FastPerm(o, v)
@@ -640,11 +639,6 @@ function PooledDataVecs{S,Q<:Integer,R<:Integer,N}(v1::PooledDataArray{S,Q,N},
             PooledDataArray(RefArray(refs2), pool))
 end
 
-function PooledDataVecs{S,R<:Integer,N}(v1::PooledDataArray{S,R,N},
-                                        v2::AbstractArray{S,N})
-    return PooledDataVecs(v1,
-                          PooledDataArray(v2))
-end
 function PooledDataVecs{S,R<:Integer,N}(v1::PooledDataArray{S,R,N},
                                         v2::AbstractArray{S,N})
     return PooledDataVecs(v1,

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -176,7 +176,7 @@ Base.std(A::DataArray; corrected::Bool=true, mean=nothing, skipna::Bool=false) =
 
 ## weighted mean
 
-function Base.mean{W,V}(a::DataArray, w::WeightVec{W,V}; skipna::Bool=false)
+function Base.mean(a::DataArray, w::WeightVec; skipna::Bool=false)
     if skipna
         v = a .* w.values
         sum(v; skipna=true) / sum(DataArray(w.values, v.na); skipna=true)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -57,9 +57,9 @@ for arr in (identity, as_dataarray, as_pda, as_dataarray_bigfloat, as_pda_bigflo
     @test arr([1 2]) ./ arr([8, 4]) == [1/8 2/8; 1/4 2/4]
     @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
     @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
-    @test arr(bitpack([true false])) .* arr(bitpack([true, true])) == [true false; true false]
-    @test arr(bitpack([true false])) .^ arr(bitpack([false, true])) == [true true; true false]
-    @test arr(bitpack([true false])) .^ arr([0, 3]) == [true true; true false]
+    @test arr(BitArray([true false])) .* arr(BitArray([true, true])) == [true false; true false]
+    @test arr(BitArray([true false])) .^ arr(BitArray([false, true])) == [true true; true false]
+    @test arr(BitArray([true false])) .^ arr([0, 3]) == [true true; true false]
 
     # NOT YET IMPLEMENTED
     # M = arr([11 12; 21 22])

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,6 +1,8 @@
 module TestData
     using Base.Test
     using DataArrays
+    using Compat
+    import Compat.String
 
     #test_context("Data types and NA's")
 
@@ -24,12 +26,20 @@ module TestData
     @assert isa(dvint2, DataVector{Int})
     @assert isa(dvint3, DataVector{Int})
     @assert isa(dvflt, DataVector{Float64})
-    @assert isa(dvstr, DataVector{ASCIIString})
+    if VERSION < v"0.5.0-dev+3876"
+        @assert isa(dvstr, DataVector{ASCIIString})
+    else
+        @assert isa(dvstr, DataVector{String})
+    end
     # @test throws_exception(DataArray([5:8], falses(2)), Exception)
 
     #test_group("PooledDataVector creation")
     pdvstr = @pdata ["one", "one", "two", "two", NA, "one", "one"]
-    @assert isa(pdvstr, PooledDataVector{ASCIIString})
+    if VERSION < v"0.5.0-dev+3876"
+        @assert isa(pdvstr, PooledDataVector{ASCIIString})
+    else
+        @assert isa(pdvstr, PooledDataVector{String})
+    end
     # @test throws_exception(PooledDataVector["one", "one", 9], Exception)
     @assert isequal(PooledDataArray(pdvstr), pdvstr)
 
@@ -51,9 +61,9 @@ module TestData
 
     #test_group("PooledDataVector utf8 support")
     pdvpp = PooledDataArray([utf8("hello")], [false])
-    @assert isa(pdvpp[1], UTF8String)
+    @assert isa(pdvpp[1], String)
     pdvpp = PooledDataArray([utf8("hello")])
-    @assert isa(pdvpp[1], UTF8String)
+    @assert isa(pdvpp[1], String)
 
     #test_group("DataVector access")
     @assert dvint[1] == 1
@@ -82,7 +92,11 @@ module TestData
     @assert size(pdvstr) == (7,)
     @assert length(pdvstr) == 7
     @assert sum(isna(pdvstr)) == 1
-    @assert eltype(pdvstr) == ASCIIString
+    if VERSION < v"0.5.0-dev+3876"
+        @assert eltype(pdvstr) == ASCIIString
+    else
+        @assert eltype(pdvstr) == String
+    end
 
     #test_group("DataVector operations")
     @assert isequal(dvint .+ 1, DataArray([2, 3, 4, 5], [false, false, true, false]))
@@ -97,8 +111,8 @@ module TestData
     @assert all(dropna(dvint) .== [1, 2, 4])
     @assert all(convert(Vector, dvint, 0) .== [1, 2, 0, 4])
     @assert all(convert(Vector, dvany, 0) .== [1, 2, 0, 4])
-    utf8three = convert(UTF8String, "three")
-    asciithree = convert(ASCIIString, "three")
+    utf8three = convert(String, "three")
+    asciithree = convert(String, "three")
     @assert all(convert(Vector, dvstr, utf8three) .== ["one", "two", "three", "four"])
     @assert all(convert(Vector, dvstr, asciithree) .== ["one", "two", "three", "four"])
     @assert all(convert(Vector{Int}, dvint2) .== [5:8;])

--- a/test/dataarray.jl
+++ b/test/dataarray.jl
@@ -69,19 +69,17 @@ module TestDataArray
     set3 = map(pdata, set1)
 
     for (dest, src, bigsrc, emptysrc, res1, res2) in Any[set1, set2, set3]
-        # Base.copy! was inconsistent until recently in 0.4-dev
-        da_or_04 = VERSION > v"0.4-" || !isa(dest, PooledDataArray)
 
         @test isequal(copy!(copy(dest), src), res1)
         @test isequal(copy!(copy(dest), 1, src), res1)
 
-        da_or_04 && @test isequal(copy!(copy(dest), 2, src, 2), res2)
+        @test isequal(copy!(copy(dest), 2, src, 2), res2)
         @test isequal(copy!(copy(dest), 2, src, 2, 1), res2)
 
         @test isequal(copy!(copy(dest), 99, src, 99, 0), dest)
 
         @test isequal(copy!(copy(dest), 1, emptysrc), dest)
-        da_or_04 && @test_throws BoundsError copy!(dest, 1, emptysrc, 1)
+        @test_throws BoundsError copy!(dest, 1, emptysrc, 1)
 
         for idx in [0, 4]
             @test_throws BoundsError copy!(dest, idx, src)
@@ -91,7 +89,7 @@ module TestDataArray
             @test_throws BoundsError copy!(dest, 1, src, idx, 1)
         end
 
-       da_or_04 && @test_throws BoundsError copy!(dest, 1, src, 1, -1)
+        @test_throws BoundsError copy!(dest, 1, src, 1, -1)
 
         @test_throws BoundsError copy!(dest, bigsrc)
 

--- a/test/datamatrix.jl
+++ b/test/datamatrix.jl
@@ -42,11 +42,11 @@ module TestDataMatrix
     #
 
     b[1, 1] = NA
-    res = a * b[1, :]
+    res = a * b[1:1, :]
     @assert all(isna(res[:, 1]))
     @assert all(!isna(res[:, 2]))
     @assert all(!isna(res[:, 3]))
-    res = a * b[2, :]
+    res = a * b[2:2, :]
     @assert all(!isna(res))
 
     #

--- a/test/literals.jl
+++ b/test/literals.jl
@@ -5,11 +5,7 @@ module TestLiterals
 
     dv = @data []
     @test isequal(dv, DataArray([], Bool[]))
-    if VERSION >= v"0.4.0-dev+848"
-        @test typeof(dv) == DataVector{Any}
-    else
-        @test typeof(dv) == DataVector{None}
-    end
+    @test typeof(dv) == DataVector{Any}
 
     dv = @data Float64[]
     @test isequal(dv, DataArray(Float64[], Bool[]))
@@ -45,14 +41,6 @@ module TestLiterals
     @test isequal(dv, DataArray(Any, 1, 2))
     @test typeof(dv) == DataMatrix{Any}
 
-    if VERSION >= v"0.4.0-"
-      println("Testing parsing 0.3 cell literal syntax, (6) warnings expected")
-    end
-    dv = @data {1, NA, 3}
-    @test isequal(dv,
-                  DataArray(Any[1, 0, 3],
-                            [false, true, false]))
-
     dm = @data [1 NA; 3 4]
     @test isequal(dm,
                   DataArray([1 0; 3 4],
@@ -68,16 +56,6 @@ module TestLiterals
     @test isequal(dm, DataArray(Any, 2, 2))
     @test typeof(dm) == DataMatrix{Any}
 
-    dm = @data {1 NA; 3 4}
-    @test isequal(dm,
-                  DataArray(Any[1 0; 3 4],
-                            [false true; false false]))
-
-    dm = @data {1 NA; 3 4}
-    @test isequal(dm,
-                  DataArray(Any[1 0; 3 4],
-                            [false true; false false]))
-
     pdv = @pdata [1, NA, 3]
     @test isequal(pdv,
                   PooledDataArray([1, 0, 3],
@@ -88,11 +66,6 @@ module TestLiterals
                   PooledDataArray(Float64[1, 0, 3],
                                   [false, true, false]))
     @test typeof(pdv) == PooledDataArray{Float64,UInt32,1}
-
-    pdv = @pdata {1, NA, 3}
-    @test isequal(pdv,
-                  PooledDataArray(Any[1, 0, 3],
-                                  [false, true, false]))
 
     pdv = @pdata [1 NA 3]
     @test isequal(pdv,
@@ -116,19 +89,10 @@ module TestLiterals
                                   [false true; false false]))
     @test typeof(pdm) == PooledDataArray{Float64,UInt32,2}
 
-    pdm = @pdata {1 NA; 3 4}
-    @test isequal(pdm,
-                  PooledDataArray(Any[1 0; 3 4],
-                                  [false true; false false]))
-
     pdm = @pdata [1 NA;
                 3 4]
     @test isequal(pdm,
                   PooledDataArray([1 0; 3 4],
-                                  [false true; false false]))
-    pdm = @pdata {1 NA; 3 4}
-    @test isequal(pdm,
-                  PooledDataArray(Any[1 0; 3 4],
                                   [false true; false false]))
 
     dv1 = @data zeros(4)

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -47,7 +47,7 @@ module TestNAs
     pda[:] = NA
     @test allna(pda)
 
-    dv = DataArray([1, 2, 3], bitpack([false, false, false]))
+    dv = DataArray([1, 2, 3], BitArray([false, false, false]))
 
     dv = DataArray(collect(1:6), fill(false, 6))
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -109,14 +109,14 @@ module TestOperators
     # Broadcasting operations between NA's and DataVector's
     dv = convert(DataArray, ones(5))
     @test_da_pda dv begin
-        for f in map(eval, [:(Base.(:.+)),
-                            :(Base.(:+)),
-                            :(Base.(:.-)),
-                            :(Base.(:-)),
-                            :(Base.(:*)),
-                            :(Base.(:.*)),
-                            :(Base.(:./)),
-                            :(Base.(:.^)),
+        for f in map(eval, [:(.+),
+                            :(+),
+                            :(.-),
+                            :(-),
+                            :(*),
+                            :(.*),
+                            :(./),
+                            :(.^),
                             :(Base.div),
                             :(Base.mod),
                             :(Base.fld),
@@ -150,7 +150,7 @@ module TestOperators
     dv = convert(DataArray, ones(5))
     dv[1] = NA
     bv = [true, false, false, true, true]
-    bbv = bitpack([true, false, false, true, true])
+    bbv = BitArray([true, false, false, true, true])
     bdv = @data [false, true, false, false, true]
     @test_da_pda dv begin
         for f in map(eval, DataArrays.array_arithmetic_operators)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -56,7 +56,7 @@ function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
         idx[d] = 1:size(A,d)
     end
 
-    r1 = f(reshape(A[idx...], Asliceshape); skipna=skipna)
+    r1 = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
 
     # determine result size and allocate
     Rsize = copy(dimsA)
@@ -111,14 +111,13 @@ function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
                 idx[otherdims] = ia
                 ridx[otherdims] = ia
                 try
-                    R[ridx...] = f(reshape(A[idx...], Asliceshape); skipna=skipna)
+                    R[ridx...] = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
                 catch e
                     if (isa(e, ErrorException) && e.msg == "Reducing over an empty array is not allowed.") || (isa(e, ArgumentError) && e.msg == "reducing over an empty collection is not allowed")
 
                         R[ridx...] = NA
                     else
                         println(typeof(e))
-                        println(e.msg)
                         rethrow(e)
                     end
                 end


### PR DESCRIPTION
All kind of stuff: new indexing, new iterations, no functors, new `getfield` syntax for operators, string changes and some other deprecations. Tests are passing now on master but the string story is not completely settled yet in `Compat.jl` so we'll need a new tag there before tests pass on 0.4. It might also be the right time to stop 0.3 support. I don't want to spend much time on making the tests pass there.

I should also mention that some of the tests are now slower than they are on 0.4. However, it's difficult to say if this is because of my changes here or because of the general slowdown on master. I profiled the `reducedim` tests and there is spent a lot of time in `inference` (even after the first run) and I can figure out why.