### PR TITLE
Use hash method for AbstractArray to fix test failure on 32-bit Windows

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -622,28 +622,6 @@ for f in (:(Base.int), :(Base.float), :(Base.bool))
     end
 end
 
-#' @description
-#'
-#' Compute the hash of an AbstractDataArray.
-#'
-#' @param da::DataArray{T} DataArray whose hash is desired.
-#'
-#' @returns h::UInt An unsigned integer hash value for `da`.
-#'
-#' @examples
-#'
-#' dv = @data [1, 2, NA, 4]
-#' k = hash(dv)
-#
-# TODO: Make sure this agrees with is_equals()
-function Base.hash(a::AbstractDataArray) # -> UInt
-    h = hash(size(a)) + 1
-    for i in 1:length(a)
-        h = hash(@compat(Int(hash(a[i]))), h)
-    end
-    return @compat UInt(h)
-end
-
 #' @internal
 #' @description
 #'


### PR DESCRIPTION
Even standard Arrays use that method, which is designed to be more
efficient.