### PR TITLE
Check for NA in DataArray inner constructor

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -29,10 +29,14 @@ type DataArray{T, N} <: AbstractDataArray{T, N}
             throw(ArgumentError(msg))
         end
         # additionally check if d does not contain NA entries
-        for i in eachindex(d)
-            if isdefined(d, i) && isna(d, i)
-                m[i] = true
+        if eltype(d) == Any
+            for i in eachindex(d)
+                if isdefined(d, i) && isna(d, i)
+                    m[i] = true
+                end
             end
+        elseif eltype(d) <: NAtype
+            m = trues(m)
         end
         new(d, m)
     end

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -28,7 +28,8 @@ type DataArray{T, N} <: AbstractDataArray{T, N}
             msg = "Data and missingness arrays must be the same size"
             throw(ArgumentError(msg))
         end
-        new(d, m)
+        # additionally check if d does not contain NA entries
+        new(d, isna(d) | m)
     end
 end
 

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -29,7 +29,12 @@ type DataArray{T, N} <: AbstractDataArray{T, N}
             throw(ArgumentError(msg))
         end
         # additionally check if d does not contain NA entries
-        new(d, isna(d) | m)
+        for i in eachindex(d)
+            if isdefined(d, i) && isna(d, i)
+                m[i] = true
+            end
+        end
+        new(d, m)
     end
 end
 


### PR DESCRIPTION
Currently inner constructor of DataArray does not check if `d` argument contains `NA` entries.
The proposed change overwrites values supplied in `m` argument with 'true' for elements of 'd'  that are 'NA'.
Closes https://github.com/JuliaStats/DataFrames.jl/issues/974.