### PR TITLE
remove methods that are deprecated in Base

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -590,38 +590,6 @@ end
 
 data(a::AbstractArray) = convert(DataArray, a)
 
-#' @description
-#'
-#' Convert a DataArray to an Array of int, float or bool type.
-#'
-#' @param da::DataArray{T} The DataArray that will be converted.
-#'
-#' @returns a::Array{Union(Int, Float64, Bool)} An Array containing the
-#'          type-converted values of `da`.
-#'
-#' @examples
-#'
-#' dv = @data [1, 2, NA, 4]
-#' v = int(dv)
-#' v = float(dv)
-#' v = bool(dv)
-#
-# TODO: Make sure these handle copying correctly
-# TODO: Remove these? They have odd behavior, because they convert to Array's.
-# TODO: Rethink multi-item documentation approach
-for f in (:(Base.int), :(Base.float), :(Base.bool))
-    @eval begin
-        function ($f)(da::DataArray) # -> DataArray
-            if anyna(da)
-                err = "Cannot convert DataArray with NA's to desired type"
-                throw(NAException(err))
-            else
-                ($f)(da.data)
-            end
-        end
-    end
-end
-
 #' @internal
 #' @description
 #'

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -590,6 +590,36 @@ end
 
 data(a::AbstractArray) = convert(DataArray, a)
 
+#' @description
+#'
+#' Convert a DataArray to an Array of float type.
+#'
+#' @param da::DataArray{T} The DataArray that will be converted.
+#'
+#' @returns a::Array{Float64} An Array containing the
+#'          type-converted values of `da`.
+#'
+#' @examples
+#'
+#' dv = @data [1, 2, NA, 4]
+#' v = float(dv)
+#
+# TODO: Make sure these handle copying correctly
+# TODO: Remove these? They have odd behavior, because they convert to Array's.
+# TODO: Rethink multi-item documentation approach
+for f in (:(Base.float),)
+    @eval begin
+        function ($f)(da::DataArray) # -> DataArray
+            if anyna(da)
+                err = "Cannot convert DataArray with NA's to desired type"
+                throw(NAException(err))
+            else
+                ($f)(da.data)
+            end
+        end
+    end
+end
+
 #' @internal
 #' @description
 #'

--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -173,13 +173,6 @@ end
 Base.sizehint!(pda::PooledDataVector, newsz::Integer) =
     sizehint!(pda.refs, newsz)
 
-function Base.sizehint(da::DataVector, newsz::Integer)
-    sizehint(da.data, newsz)
-    sizehint(da.na, newsz)
-end
-
-Base.sizehint(pda::PooledDataVector, newsz::Integer) = sizehint(pda.refs, newsz)
-
 # Pad a vector with NA's
 
 function padNA(dv::AbstractDataVector,


### PR DESCRIPTION
now removed in 0.5 - defining these wasn't giving deprecation warnings,
but calling them should have been?