### PR TITLE
Use Base.promote_op() for arithmetic operators

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -2,20 +2,6 @@ using DataArrays, Base.@get!
 using Base.Broadcast: bitcache_chunks, bitcache_size, dumpbitcache,
                       promote_eltype, broadcast_shape, eltype_plus
 
-if isdefined(Base.Broadcast, :type_minus)
-    using Base.Broadcast: type_minus, type_div, type_pow
-    const _type_minus = type_minus
-    const _type_rdiv = type_div
-    const _type_ldiv = type_div
-    const _type_pow = type_pow
-else
-    using Base.Broadcast: promote_op
-    _type_minus(T, S) = promote_op(@functorize(-), T, S)
-    _type_rdiv(T, S) = promote_op(@functorize(/), T, S)
-    _type_ldiv(T, S) = promote_op(@functorize(\), T, S)
-    _type_pow(T, S) = promote_op(@functorize(^), T, S)
-end
-
 # Check that all arguments are broadcast compatible with shape
 # Differs from Base in that we check for exact matches
 function check_broadcast_shape(shape::Dims, As::(@compat Union{AbstractArray,Number})...)
@@ -304,30 +290,43 @@ end
 @da_broadcast_vararg (.*)(As...) = databroadcast(*, As...)
 @da_broadcast_binary (.%)(A, B) = databroadcast(%, A, B)
 @da_broadcast_vararg (.+)(As...) = broadcast!(+, DataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
-@da_broadcast_binary (.-)(A, B) = broadcast!(-, DataArray(_type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
-@da_broadcast_binary (./)(A, B) = broadcast!(/, DataArray(_type_rdiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
-@da_broadcast_binary (.\)(A, B) = broadcast!(\, DataArray(_type_ldiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+@da_broadcast_binary (.-)(A, B) =
+    broadcast!(-, DataArray(promote_op(@functorize(-), eltype(A), eltype(B)),
+                            broadcast_shape(A,B)), A, B)
+@da_broadcast_binary (./)(A, B) =
+    broadcast!(/, DataArray(promote_op(@functorize(/), eltype(A), eltype(B)),
+                            broadcast_shape(A, B)), A, B)
+@da_broadcast_binary (.\)(A, B) =
+    broadcast!(\, DataArray(promote_op(@functorize(\), eltype(A), eltype(B)),
+                            broadcast_shape(A, B)), A, B)
 (.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
 (.^)(A::BitArray, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
 (.^)(A::AbstractArray{Bool}, B::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}})) = databroadcast(>=, A, B)
 (.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::BitArray) = databroadcast(>=, A, B)
 (.^)(A::(@compat Union{DataArray{Bool}, PooledDataArray{Bool}}), B::AbstractArray{Bool}) = databroadcast(>=, A, B)
-@da_broadcast_binary (.^)(A, B) = broadcast!(^, DataArray(_type_pow(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+@da_broadcast_binary (.^)(A, B) =
+    broadcast!(^, DataArray(promote_op(@functorize(^), eltype(A), eltype(B)),
+                            broadcast_shape(A, B)), A, B)
 
 # XXX is a PDA the right return type for these?
 Base.broadcast(f::Function, As::PooledDataArray...) = pdabroadcast(f, As...)
 (.*)(As::PooledDataArray...) = pdabroadcast(*, As...)
 (.%)(A::PooledDataArray, B::PooledDataArray) = pdabroadcast(%, A, B)
-(.+)(As::PooledDataArray...) = broadcast!(+, PooledDataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
+(.+)(As::PooledDataArray...) =
+    broadcast!(+, PooledDataArray(eltype_plus(As...), broadcast_shape(As...)), As...)
 (.-)(A::PooledDataArray, B::PooledDataArray) =
-    broadcast!(-, PooledDataArray(_type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
+    broadcast!(-, PooledDataArray(promote_op(@functorize(-), eltype(A), eltype(B)),
+                                  broadcast_shape(A,B)), A, B)
 (./)(A::PooledDataArray, B::PooledDataArray) =
-    broadcast!(/, PooledDataArray(_type_rdiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+    broadcast!(/, PooledDataArray(promote_op(@functorize(/), eltype(A), eltype(B)),
+                                  broadcast_shape(A, B)), A, B)
 (.\)(A::PooledDataArray, B::PooledDataArray) =
-    broadcast!(\, PooledDataArray(_type_ldiv(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+    broadcast!(\, PooledDataArray(promote_op(@functorize(\), eltype(A), eltype(B)),
+                                  broadcast_shape(A, B)), A, B)
 (.^)(A::PooledDataArray{Bool}, B::PooledDataArray{Bool}) = databroadcast(>=, A, B)
 (.^)(A::PooledDataArray, B::PooledDataArray) =
-    broadcast!(^, PooledDataArray(_type_pow(eltype(A), eltype(B)), broadcast_shape(A, B)), A, B)
+    broadcast!(^, PooledDataArray(promote_op(@functorize(^), eltype(A), eltype(B)),
+                                  broadcast_shape(A, B)), A, B)
 
 for (sf, vf) in zip(scalar_comparison_operators, array_comparison_operators)
     @eval begin

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -265,7 +265,7 @@ macro da_broadcast_vararg(func)
         rep = Any[Symbol("A_$(i)") for i = 1:n]
         push!(rep, va)
         exreplace!(def.args[2], va, rep)
-        rep = cell(n+1)
+        rep = Vector{Any}(n+1)
         for i = 1:aa
             rep[i] = Expr(:(::), Symbol("A_$i"), AbstractArray)
         end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -56,12 +56,18 @@ function mapreduce_pairwise_impl_skipna{T}(f, op, A::DataArray{T}, bytefirst::In
     op(v1, v2)
 end
 
+if isdefined(Base, :pairwise_blocksize)
+    sum_pairwise_blocksize(f) = Base.pairwise_blocksize(f, +)
+else
+    const sum_pairwise_blocksize = Base.sum_pairwise_blocksize
+end
+
 mapreduce_impl_skipna{T}(f, op, A::DataArray{T}) =
     mapreduce_seq_impl_skipna(f, op, T, A, 1, length(A.data))
 mapreduce_impl_skipna(f, op::typeof(@functorize(+)), A::DataArray) =
     mapreduce_pairwise_impl_skipna(f, op, A, 1, length(A.na.chunks),
                                    length(A.na)-countnz(A.na),
-                                   max(128, Base.sum_pairwise_blocksize(f)))
+                                   max(128, sum_pairwise_blocksize(f)))
 
 ## general mapreduce interface
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -58,7 +58,7 @@ bfz = convert(DataArray{BigFloat}, z)
 @test sum(fz; skipna=true) === 130.0
 @test sum(bfz; skipna=true) == 130
 
-bs = Base.sum_pairwise_blocksize(@functorize(identity))
+bs = DataArrays.sum_pairwise_blocksize(@functorize(identity))
 for n in [bs-64, bs-1, bs, bs+1, bs+2, 2*bs-2:2*bs+3..., 4*bs-2:4*bs+3...]
     da = DataArray(randn(n))
     s = sum(da.data)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -48,7 +48,7 @@ function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
 
     otherdims = setdiff(alldims, dims)
 
-    idx = cell(ndimsA)
+    idx = Vector{Any}(ndimsA)
     fill!(idx, 1)
     Asliceshape = tuple(dimsA[dims]...)
     itershape   = tuple(dimsA[otherdims]...)
@@ -69,7 +69,7 @@ function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
     Rsize[dims] = [size(r1)...; ones(Int,max(0,length(dims)-ndims(r1)))]
     R = similar(r1, tuple(Rsize...))
 
-    ridx = cell(ndims(R))
+    ridx = Vector{Any}(ndims(R))
     fill!(ridx, 1)
     for d in dims
         ridx[d] = 1:size(R,d)


### PR DESCRIPTION
This fixes support for cases in which the return type is different
from the inputs, in particular Date. Also makes handling of /
a bit less of a special case.

Fixes https://github.com/JuliaStats/DataFrames.jl/issues/987.