### PR TITLE
Allowed bare Ints as repeat keyword args

### DIFF
--- a/src/extras.jl
+++ b/src/extras.jl
@@ -64,15 +64,15 @@ end
 cut(x::AbstractVector, ngroups::Integer) = cut(x, quantile(x, [1 : ngroups - 1] / ngroups))
 
 function Base.repeat{T,N}(A::DataArray{T,N};
-                          inner::Array{Int} = ones(Int, ndims(A)),
-                          outer::Array{Int} = ones(Int, ndims(A)))
+                          inner = ones(Int, ndims(A)),
+                          outer = ones(Int, ndims(A)))
     DataArray{T,N}(Compat.repeat(A.data; inner=inner, outer=outer),
                    bitpack(Compat.repeat(A.na; inner=inner, outer=outer)))
 end
 
 function Base.repeat{T,R,N}(A::PooledDataArray{T,R,N};
-                            inner::Array{Int} = ones(Int, ndims(A)),
-                            outer::Array{Int} = ones(Int, ndims(A)))
+                            inner = ones(Int, ndims(A)),
+                            outer = ones(Int, ndims(A)))
     PooledDataArray(RefArray{R,N}(Compat.repeat(A.refs; inner=inner, outer=outer)),
                     A.pool)
 end

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -49,4 +49,9 @@ module TestExtras
     @test isequal(repeat(@pdata [:a :b NA]; inner = [2,1], outer = [1,3]),
                   @pdata [:a :b NA :a :b NA :a :b NA;
                           :a :b NA :a :b NA :a :b NA])
+    @test isequal(repeat(@data [3.0, 2.0, NA]; inner = 2, outer = 1),
+                  @data [3.0, 3.0, 2.0, 2.0, NA, NA])
+    @test isequal(repeat(@pdata ["a", "b", NA]; inner = 2, outer = 1),
+                  @pdata ["a", "a", "b", "b", NA, NA])
+
 end


### PR DESCRIPTION
This prevents breakage of stack and crossjoin in DataFrames.jl