### PR TITLE
Loosen type signature for repeat()

### DIFF
--- a/src/extras.jl
+++ b/src/extras.jl
@@ -64,15 +64,15 @@ end
 cut(x::AbstractVector, ngroups::Integer) = cut(x, quantile(x, [1 : ngroups - 1] / ngroups))
 
 function Base.repeat{T,N}(A::DataArray{T,N};
-                          inner::Array{Int} = ones(Int, ndims(A)),
-                          outer::Array{Int} = ones(Int, ndims(A)))
+                          inner = ntuple(x->1, ndims(A)),
+                          outer = ntuple(x->1, ndims(A)))
     DataArray{T,N}(Compat.repeat(A.data; inner=inner, outer=outer),
                    BitArray(Compat.repeat(A.na; inner=inner, outer=outer)))
 end
 
 function Base.repeat{T,R,N}(A::PooledDataArray{T,R,N};
-                            inner::Array{Int} = ones(Int, ndims(A)),
-                            outer::Array{Int} = ones(Int, ndims(A)))
+                            inner = ntuple(x->1, ndims(A)),
+                            outer = ntuple(x->1, ndims(A)))
     PooledDataArray(RefArray{R,N}(Compat.repeat(A.refs; inner=inner, outer=outer)),
                     A.pool)
 end

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -40,9 +40,9 @@ module TestExtras
     ## repeat
     ##########
 
-    @test isequal(repeat(@data [3.0, 2.0, NA]; inner = [2], outer = [1]),
+    @test isequal(repeat(@data [3.0, 2.0, NA]; inner = 2, outer = 1),
                   @data [3.0, 3.0, 2.0, 2.0, NA, NA])
-    @test isequal(repeat(@pdata ["a", "b", NA]; inner = [2], outer = [1]),
+    @test isequal(repeat(@pdata ["a", "b", NA]; inner = 2, outer = 1),
                   @pdata ["a", "a", "b", "b", NA, NA])
     @test isequal(repeat(@data [1 2; 3 NA]; inner = [1, 2], outer = [2, 1]),
                   @data [1 1 2 2; 3 3 NA NA; 1 1 2 2; 3 3 NA NA])


### PR DESCRIPTION
In Julia 0.5 and in Compat.jl, repeat() accepts any iterable
argument, in particular scalars. The restriction triggers an
error in DataFrames on Julia 0.5.