### PR TITLE
add a less specific version of setlevels!; fixes #201 and tests on Gadfly.jl

### DIFF
--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -399,6 +399,9 @@ function setlevels!{T,R}(x::PooledDataArray{T,R}, newpool::AbstractVector{T})
     end
 end
 
+setlevels!{T, R}(x::PooledDataArray{T, R},
+                 newpool::AbstractVector) = setlevels!(x, convert(Array{T}, newpool))
+
 function setlevels(x::PooledDataArray, d::Dict)
     newpool = copy(DataArray(x.pool))
     # An NA in `v` is put in the pool; that will cause it to become NA

--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -27,6 +27,8 @@ module TestPDA
     @assert levels(setlevels!(copy(p), [1,8,9, 10])) == [1, 8, 9, 10]
     @assert levels(setlevels!(copy(p), Dict([(1, 111)]))) == [111, 8, 9]
     @assert levels(setlevels!(copy(p), Dict([(1, 111), (8, NA)]))) == [111, 9]
+    # issue #201
+    @assert levels(setlevels!(@pdata([1.0, 2.0]), [3,4])) == [3.0, 4.0]
 
     y = @pdata [1, NA, -2, 1, NA, 4, NA]
     @assert isequal(unique(y), @pdata [1, NA, -2, 4])


### PR DESCRIPTION
Currently the type signature of setlevels! is extremely strict and it would be best to allow the user some more flexibility. This should also fix Gadfly's tests being broken (at least on 0.4).

See #201 