### PR TITLE
Fix reducedim tests for backports to 0.5

### DIFF
--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -127,10 +127,10 @@ for Areduc in (DataArray(rand(3, 4, 5, 6)),
             (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)]
             # println("region = $region, skipna = $skipna")
 
-            if VERSION < v"0.6.0-dev.1121"
+            if VERSION < v"0.5.1-pre+19"
                 outputs = Any[DataArray(fill(NaN, Base.reduced_dims(size(Areduc), region)))]
             else
-                outputs = Any[DataArray(fill(NaN, length.(Base.reduced_indices(indices(Areduc), region))))]
+                outputs = Any[DataArray(fill(NaN, map(length, Base.reduced_indices(indices(Areduc), region))))]
             end
             has_na = anyna(Areduc)
             if has_na && !skipna


### PR DESCRIPTION
I think the backporting in https://github.com/JuliaLang/julia/pull/19103 broke the tests on 0.5.