### PR TITLE
Change unique() to return values in the same ordering as levels for PDAs

### DIFF
--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -31,16 +31,20 @@ module TestPDA
     @assert levels(setlevels!(@pdata([1.0, 2.0]), [3,4])) == [3.0, 4.0]
 
     y = @pdata [1, NA, -2, 1, NA, 4, NA]
-    @assert isequal(unique(y), @pdata [1, NA, -2, 4])
-    @assert isequal(unique(reverse(y)), @data [NA, 4, 1, -2])
-    @assert isequal(unique(dropna(y)), @data [1, -2, 4])
-    @assert isequal(unique(reverse(dropna(y))), @data [4, 1, -2])
+    @assert isequal(unique(y), @pdata [-2, 1, 4, NA])
+    @assert isequal(unique(reverse(y)), @data [-2, 1, 4, NA])
+    @assert isequal(unique(dropna(y)), @data levels(dropna(y)))
+    @assert isequal(unique(reverse(dropna(y))), @data levels(reverse(dropna(y))))
 
     z = @pdata ["frank", NA, "gertrude", "frank", NA, "herbert", NA]
-    @assert isequal(unique(z), @pdata ["frank", NA, "gertrude", "herbert"])
-    @assert isequal(unique(reverse(z)), @pdata [NA, "herbert", "frank", "gertrude"])
-    @assert isequal(unique(dropna(z)), @pdata ["frank", "gertrude", "herbert"])
-    @assert isequal(unique(reverse(dropna(z))), @pdata ["herbert", "frank", "gertrude"])
+    @assert isequal(unique(z), @pdata ["frank", "gertrude", "herbert",  NA])
+    @assert isequal(unique(reverse(z)), @pdata ["frank", "gertrude", "herbert",  NA])
+    @assert isequal(unique(dropna(z)), @data levels(dropna(z)))
+    @assert isequal(unique(reverse(dropna(z))), @data levels(reverse(dropna(z))))
+
+    # check case where some levels are not present in data
+    z[3] = "frank"
+    @assert isequal(unique(z), @pdata ["frank", "herbert",  NA])
 
     # check case where only NA occurs in final position
     @assert isequal(unique(@pdata [1, 2, 1, NA]), @pdata [1, 2, NA])


### PR DESCRIPTION
While the generic unique() method says it preserves the order of appearance,
the ordering of levels is more likely to be useful. In particular, it will
allow StatsModels to use unique() to get levels present in the data in the
user-defined order, with the first level as reference by default.

The new code (inspired by CategoricalArrays) is also more efficient in the
common case where all values are encountered well before the end of the array,
by doing a periodic short-circuiting check.

-------
See https://github.com/JuliaStats/StatsModels.jl/pull/13#discussion_r101899349. The current behavior was chosen after discussion at  https://github.com/JuliaStats/DataArrays.jl/issues/92, but it looks like the issues where mainly about `DataArray`, not `PooledDataArray`. It's slightly annoying to deviate from the standard behavior of `unique`, but I can't think of cases where the order of appearance would be more useful than the ordering of levels, which should be carefully chosen (else using a PDA doesn't make much sense).

The other solution is to provide a separate function for this, but that sounds overkill.