### PR TITLE
Update tests to use testsets

### DIFF
--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1,14 +1,11 @@
-module TestAbstractArray
-    using Base.Test
-    using DataArrays
-
+@testset "AbstractArray" begin
     unsorted_dv = @data [2, 1, NA]
 
     # TODO: Make this work
     # tiedrank(dv)
 
-    @assert first(unsorted_dv) == 2
-    @assert isna(last(unsorted_dv))
+    @test first(unsorted_dv) == 2
+    @test isna(last(unsorted_dv))
 
     # isna with AbstractArray
     a = [1, 2, 3]
@@ -16,6 +13,6 @@ module TestAbstractArray
     a = Any[1, 2, NA, 3]
     @test isna(a) == [false, false, true, false]
     for i = 1:length(a)
-	    @test isna(a, i) == isna(a)[i]
-	end
+        @test isna(a, i) == isna.(a)[i]
+    end
 end

--- a/test/booleans.jl
+++ b/test/booleans.jl
@@ -1,26 +1,23 @@
-module TestBooleans
-    using Base.Test
-    using DataArrays
+@testset "Booleans" begin
+    @test NA | true == true
+    @test isna(NA | false)
+    @test isna(NA | NA)
+    @test true | NA == true
+    @test isna(false | NA)
 
-    @assert NA | true == true
-    @assert isna(NA | false)
-    @assert isna(NA | NA)
-    @assert true | NA == true
-    @assert isna(false | NA)
+    @test isna(NA & true)
+    @test NA & false == false
+    @test isna(NA & NA)
+    @test isna(true & NA)
+    @test false & NA == false
 
-    @assert isna(NA & true)
-    @assert NA & false == false
-    @assert isna(NA & NA)
-    @assert isna(true & NA)
-    @assert false & NA == false
+    @test any((@data [1, 2, NA]) .== 1) == true
+    @test any((@data [NA, 1, 2]) .== 1) == true
+    @test isna(any((@data [1, 2, NA]) .== 3))
+    @test any((@data [1, 2, 3] ).== 4) == false
 
-    @assert any((@data [1, 2, NA]) .== 1) == true
-    @assert any((@data [NA, 1, 2]) .== 1) == true
-    @assert isna(any((@data [1, 2, NA]) .== 3))
-    @assert any((@data [1, 2, 3] ).== 4) == false
-
-    @assert isna(all((@data [1, 1, NA]) .== 1))
-    @assert isna(all((@data [NA, 1, 1]) .== 1))
-    @assert all((@data [1, 1, 1]) .== 1) == true
-    @assert all((@data [1, 2, 1]) .== 1) == false
+    @test isna(all((@data [1, 1, NA]) .== 1))
+    @test isna(all((@data [NA, 1, 1]) .== 1))
+    @test all((@data [1, 1, 1]) .== 1) == true
+    @test all((@data [1, 2, 1]) .== 1) == false
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,133 +1,131 @@
-module TestBroadcast
-using DataArrays, Base.Test
+@testset "Broadcast" begin
+    # Based on broadcast tests from base
+    as_dataarray(x) = convert(DataArray, x)
+    as_dataarray_bigfloat(x) = convert(DataArray{BigFloat}, x)
+    as_pda(x) = convert(PooledDataArray, x)
+    as_pda_bigfloat(x) = convert(PooledDataArray{BigFloat}, x)
 
-# Based on broadcast tests from base
-as_dataarray(x) = convert(DataArray, x)
-as_dataarray_bigfloat(x) = convert(DataArray{BigFloat}, x)
-as_pda(x) = convert(PooledDataArray, x)
-as_pda_bigfloat(x) = convert(PooledDataArray{BigFloat}, x)
+    bittest(f::Function, a...) = (@test broadcast(f, a...) ==
+            invoke(broadcast, Tuple{Function,ntuple(x->AbstractArray, length(a))...}, f, a...))
+    n1 = 21
+    n2 = 32
+    n3 = 17
+    rb = 1:5
 
-bittest(f::Function, a...) = (@test broadcast(f, a...) ==
-        invoke(broadcast, Tuple{Function,ntuple(x->AbstractArray, length(a))...}, f, a...))
-n1 = 21
-n2 = 32
-n3 = 17
-rb = 1:5
+    @test broadcast!(+, DataArray(Int, 2, 2), eye(2), [1, 4]) == [2 1; 4 5]
+    @test broadcast!(+, DataArray(Int, 2, 2), eye(2), [1  4]) == [2 4; 1 5]
+    @test broadcast!(+, DataArray(Int, 2, 2), [1  0], [1, 4]) == [2 1; 5 4]
+    @test broadcast!(+, DataArray(Int, 2, 2), [1, 0], [1  4]) == [2 5; 1 4]
+    @test broadcast!(+, DataArray(Int, 2), [1, 0], [1, 4]) == [2, 4]
+    @test broadcast!(+, DataArray(Int, 2), [1, 0], 2) == [3, 2]
+    for arr in (identity, as_dataarray, as_pda, as_dataarray_bigfloat, as_pda_bigfloat)
+        @test broadcast(+, arr(eye(2)), arr([1, 4])) == [2 1; 4 5]
+        @test broadcast(+, arr(eye(2)), arr([1  4])) == [2 4; 1 5]
+        @test broadcast(+, arr([1  0]), arr([1, 4])) == [2 1; 5 4]
+        @test broadcast(+, arr([1, 0]), arr([1  4])) == [2 5; 1 4]
+        @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
+        @test broadcast(+, arr([1, 0]), 2) == [3, 2]
 
-@test broadcast!(+, DataArray(Int, 2, 2), eye(2), [1, 4]) == [2 1; 4 5]
-@test broadcast!(+, DataArray(Int, 2, 2), eye(2), [1  4]) == [2 4; 1 5]
-@test broadcast!(+, DataArray(Int, 2, 2), [1  0], [1, 4]) == [2 1; 5 4]
-@test broadcast!(+, DataArray(Int, 2, 2), [1, 0], [1  4]) == [2 5; 1 4]
-@test broadcast!(+, DataArray(Int, 2), [1, 0], [1, 4]) == [2, 4]
-@test broadcast!(+, DataArray(Int, 2), [1, 0], 2) == [3, 2]
-for arr in (identity, as_dataarray, as_pda, as_dataarray_bigfloat, as_pda_bigfloat)
-    @test broadcast(+, arr(eye(2)), arr([1, 4])) == [2 1; 4 5]
-    @test broadcast(+, arr(eye(2)), arr([1  4])) == [2 4; 1 5]
-    @test broadcast(+, arr([1  0]), arr([1, 4])) == [2 1; 5 4]
-    @test broadcast(+, arr([1, 0]), arr([1  4])) == [2 5; 1 4]
-    @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
-    @test broadcast(+, arr([1, 0]), 2) == [3, 2]
+        @test isequal(broadcast(+, arr(eye(2)), arr(@data [NA, 4])), @data [NA NA; 4 5])
+        @test isequal(broadcast(+, arr(eye(2)), arr(@data [NA  4])), @data [NA 4; NA 5])
+        @test isequal(broadcast(+, arr(@data [1  NA]), arr([1, 4])), @data [2 NA; 5 NA])
+        @test isequal(broadcast(+, arr(@data [1, NA]), arr([1  4])), @data [2 5; NA NA])
+        @test isequal(broadcast(+, arr(@data [1, NA]), arr([1, 4])), @data [2, NA])
 
-    @test isequal(broadcast(+, arr(eye(2)), arr(@data [NA, 4])), @data [NA NA; 4 5])
-    @test isequal(broadcast(+, arr(eye(2)), arr(@data [NA  4])), @data [NA 4; NA 5])
-    @test isequal(broadcast(+, arr(@data [1  NA]), arr([1, 4])), @data [2 NA; 5 NA])
-    @test isequal(broadcast(+, arr(@data [1, NA]), arr([1  4])), @data [2 5; NA NA])
-    @test isequal(broadcast(+, arr(@data [1, NA]), arr([1, 4])), @data [2, NA])
+        @test @inferred(arr(eye(2)) .+ arr([1, 4])) == arr([2 1; 4 5])
+        @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
+        @test arr([1  0]) .+ arr([1, 4]) == arr([2 1; 5 4])
+        @test arr([1, 0]) .+ arr([1  4]) == arr([2 5; 1 4])
+        @test arr([1, 0]) .+ arr([1, 4]) == arr([2, 4])
+        @test arr([1]) .+ arr([]) == arr([])
 
-    @test @inferred(arr(eye(2)) .+ arr([1, 4])) == arr([2 1; 4 5])
-    @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
-    @test arr([1  0]) .+ arr([1, 4]) == arr([2 1; 5 4])
-    @test arr([1, 0]) .+ arr([1  4]) == arr([2 5; 1 4])
-    @test arr([1, 0]) .+ arr([1, 4]) == arr([2, 4])
-    @test arr([1]) .+ arr([]) == arr([])
+        A = arr(eye(2)); @test broadcast!(+, A, A, arr([1, 4])) == arr([2 1; 4 5])
+        A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
+        A = arr([1  0]); try
+            broadcast!(+, A, A, arr([1, 4]))
+            throw(ArgumentError("'broadcast!(+, A, A, arr([1, 4]))' didn't throw an error"))
+        catch e
+            isa(e, DimensionMismatch) || isa(e, ErrorException) || rethrow(e)
+        end
+        A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
+        A = arr([1  0]); @test broadcast!(+, A, A, 2) == arr([3 2])
 
-    A = arr(eye(2)); @test broadcast!(+, A, A, arr([1, 4])) == arr([2 1; 4 5])
-    A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
-    A = arr([1  0]); try
-        broadcast!(+, A, A, arr([1, 4]))
-        throw(ArgumentError("'broadcast!(+, A, A, arr([1, 4]))' didn't throw an error"))
-    catch e
-        isa(e, DimensionMismatch) || isa(e, ErrorException) || rethrow(e)
+        @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
+        @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]
+        @test arr([1 2]) ./ arr([8, 4]) == [1/8 2/8; 1/4 2/4]
+        @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
+        @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
+        @test arr(BitArray([true false])) .* arr(BitArray([true, true])) == [true false; true false]
+        @test arr(BitArray([true false])) .^ arr(BitArray([false, true])) == [true true; true false]
+        @test arr(BitArray([true false])) .^ arr([0, 3]) == [true true; true false]
+
+        # NOT YET IMPLEMENTED
+        # M = arr([11 12; 21 22])
+        # @test broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2])) == [21 11; 12 22]
+        # @test_throws BoundsError broadcast_getindex(M, eye(Int, 2).+1,arr([1, -1]))
+        # @test_throws BoundsError broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2]), [2])
+        # @test broadcast_getindex(M, eye(Int, 2).+1,arr([2, 1]), [1]) == [22 12; 11 21]
+
+        # A = arr(zeros(2,2))
+        # broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2).+1,arr([1, 2]))
+        # @test A == M
+        # broadcast_setindex!(A, 5, [1,2], [2 2])
+        # @test A == [11 5; 21 5]
+        # broadcast_setindex!(A, 7, [1,2], [1 2])
+        # @test A == fill(7, 2, 2)
+        # A = arr(zeros(3,3))
+        # broadcast_setindex!(A, 10:12, 1:3, 1:3)
+        # @test A == diagm(10:12)
+        # @test_throws BoundsError broadcast_setindex!(A, 7, [1,-1], [1 2])
+
+        for f in (==, (<), (!=), (<=))
+            bittest(f, arr(eye(2)), arr([1, 4]))
+            bittest(f, arr(eye(2)), arr([1  4]))
+            bittest(f, arr([0, 1]), arr([1  4]))
+            bittest(f, arr([0  1]), arr([1, 4]))
+            bittest(f, arr([1, 0]), arr([1, 4]))
+
+            # these should work once indexing is fixed
+            bittest(f, arr(rand(rb, n1, n2, n3)), arr(rand(rb, n1, n2, n3)))
+            bittest(f, arr(rand(rb,  1, n2, n3)), arr(rand(rb, n1,  1, n3)))
+            bittest(f, arr(rand(rb,  1, n2,  1)), arr(rand(rb, n1,  1, n3)))
+            bittest(f, arr(bitrand(n1, n2, n3)), arr(bitrand(n1, n2, n3)))
+        end
     end
-    A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
-    A = arr([1  0]); @test broadcast!(+, A, A, 2) == arr([3 2])
 
-    @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
-    @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]
-    @test arr([1 2]) ./ arr([8, 4]) == [1/8 2/8; 1/4 2/4]
-    @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
-    @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
-    @test arr(BitArray([true false])) .* arr(BitArray([true, true])) == [true false; true false]
-    @test arr(BitArray([true false])) .^ arr(BitArray([false, true])) == [true true; true false]
-    @test arr(BitArray([true false])) .^ arr([0, 3]) == [true true; true false]
+    r1 = 1:1
+    r2 = 1:5
+    ratio = @data [1,1/2,1/3,1/4,1/5]
+    @test r1.*r2 == collect(1:5)
+    @test r1./r2 == ratio
+    m = @data [1 2]
+    @test m.*r2 == DataArray([1:5 2:2:10])
+    @test m./r2 ≈ [ratio 2ratio]
+    @test m./collect(r2) ≈ [ratio 2ratio]
 
-    # NOT YET IMPLEMENTED
-    # M = arr([11 12; 21 22])
-    # @test broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2])) == [21 11; 12 22]
-    # @test_throws BoundsError broadcast_getindex(M, eye(Int, 2).+1,arr([1, -1]))
-    # @test_throws BoundsError broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2]), [2])
-    # @test broadcast_getindex(M, eye(Int, 2).+1,arr([2, 1]), [1]) == [22 12; 11 21]
+    @test @inferred([0,1.2].+reshape([0,-2],1,1,2)) == reshape([0 -2; 1.2 -0.8],2,1,2)
+    rt = Base.return_types(.+, (DataArray{Float64, 3}, DataArray{Int, 1}))
+    @test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
+    rt = Base.return_types(broadcast, (typeof(+), Array{Float64, 3}, DataArray{Int, 1}))
+    @test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
+    rt = Base.return_types(broadcast!, (typeof(+), DataArray{Float64, 3}, Array{Float64, 3}, Array{Int, 1}))
+    @test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
 
-    # A = arr(zeros(2,2))
-    # broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2).+1,arr([1, 2]))
-    # @test A == M
-    # broadcast_setindex!(A, 5, [1,2], [2 2])
-    # @test A == [11 5; 21 5]
-    # broadcast_setindex!(A, 7, [1,2], [1 2])
-    # @test A == fill(7, 2, 2)
-    # A = arr(zeros(3,3))
-    # broadcast_setindex!(A, 10:12, 1:3, 1:3)
-    # @test A == diagm(10:12)
-    # @test_throws BoundsError broadcast_setindex!(A, 7, [1,-1], [1 2])
+    # Test String broadcast
+    @test broadcast(==, @data(["a", "b", "c", "d"]), "a") == @data([true,false,false,false])
 
-    for f in (==, (<), (!=), (<=))
-        bittest(f, arr(eye(2)), arr([1, 4]))
-        bittest(f, arr(eye(2)), arr([1  4]))
-        bittest(f, arr([0, 1]), arr([1  4]))
-        bittest(f, arr([0  1]), arr([1, 4]))
-        bittest(f, arr([1, 0]), arr([1, 4]))
+    # Test broadcasting of functions that do something besides propagate NA
+    @test isequal(broadcast(isequal, @data([NA, 1]), @data([NA 1])), @data([true false; false true]))
+    @test isequal(broadcast(isequal, @pdata([NA, 1]), @data([NA 1])), @data([true false; false true]))
+    @test isequal(broadcast(isequal, @data([NA, 1]), @pdata([NA 1])), @data([true false; false true]))
+    @test isequal(broadcast(isequal, @pdata([NA, 1]), @pdata([NA 1])), @pdata([true false; false true]))
+    @test isequal(broadcast(&, @data([NA, false]), @data([NA true false])), @data([NA NA false; false false false]))
+    @test isequal(broadcast(|, @data([NA, false]), @data([NA true false])), @data([NA true NA; NA true false]))
 
-        # these should work once indexing is fixed
-        bittest(f, arr(rand(rb, n1, n2, n3)), arr(rand(rb, n1, n2, n3)))
-        bittest(f, arr(rand(rb,  1, n2, n3)), arr(rand(rb, n1,  1, n3)))
-        bittest(f, arr(rand(rb,  1, n2,  1)), arr(rand(rb, n1,  1, n3)))
-        bittest(f, arr(bitrand(n1, n2, n3)), arr(bitrand(n1, n2, n3)))
-    end
-end
-
-r1 = 1:1
-r2 = 1:5
-ratio = @data [1,1/2,1/3,1/4,1/5]
-@test r1.*r2 == collect(1:5)
-@test r1./r2 == ratio
-m = @data [1 2]
-@test m.*r2 == DataArray([1:5 2:2:10])
-@test m./r2 ≈ [ratio 2ratio]
-@test m./collect(r2) ≈ [ratio 2ratio]
-
-@test @inferred([0,1.2].+reshape([0,-2],1,1,2)) == reshape([0 -2; 1.2 -0.8],2,1,2)
-rt = Base.return_types(.+, (DataArray{Float64, 3}, DataArray{Int, 1}))
-@test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
-rt = Base.return_types(broadcast, (typeof(+), Array{Float64, 3}, DataArray{Int, 1}))
-@test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
-rt = Base.return_types(broadcast!, (typeof(+), DataArray{Float64, 3}, Array{Float64, 3}, Array{Int, 1}))
-@test length(rt) == 1 && rt[1] == DataArray{Float64, 3}
-
-# Test String broadcast
-@test broadcast(==, @data(["a", "b", "c", "d"]), "a") == @data([true,false,false,false])
-
-# Test broadcasting of functions that do something besides propagate NA
-@test isequal(broadcast(isequal, @data([NA, 1]), @data([NA 1])), @data([true false; false true]))
-@test isequal(broadcast(isequal, @pdata([NA, 1]), @data([NA 1])), @data([true false; false true]))
-@test isequal(broadcast(isequal, @data([NA, 1]), @pdata([NA 1])), @data([true false; false true]))
-@test isequal(broadcast(isequal, @pdata([NA, 1]), @pdata([NA 1])), @pdata([true false; false true]))
-@test isequal(broadcast(&, @data([NA, false]), @data([NA true false])), @data([NA NA false; false false false]))
-@test isequal(broadcast(|, @data([NA, false]), @data([NA true false])), @data([NA true NA; NA true false]))
-
-# Test map!
-@test map!(+, DataArray(Float64, 2), @data([1, 2]), @data([1, 2])) == @data([2, 4])
-x = @data([-1, -2])
-@test map!(abs, x, x) == @data([1, 2])
-@test isequal(map!(+, DataArray(Float64, 3), @data([1, NA, 3]), @data([NA, 2, 3])), @data([NA, NA, 6]))
-@test map!(isequal, DataArray(Float64, 3), @data([1, NA, NA]), @data([1, NA, 3])) == @data([true, true, false])
+    # Test map!
+    @test map!(+, DataArray(Float64, 2), @data([1, 2]), @data([1, 2])) == @data([2, 4])
+    x = @data([-1, -2])
+    @test map!(abs, x, x) == @data([1, 2])
+    @test isequal(map!(+, DataArray(Float64, 3), @data([1, NA, 3]), @data([NA, 2, 3])), @data([NA, NA, 6]))
+    @test map!(isequal, DataArray(Float64, 3), @data([1, NA, NA]), @data([1, NA, 3])) == @data([true, true, false])
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,128 +1,125 @@
-module TestConstructors
-    using Base.Test
-    using DataArrays
-
+@testset "Constructors" begin
     #
     # NA's
     #
 
-    @assert isna(NAtype())
-    @assert isna(NA)
+    @test isna(NAtype())
+    @test isna(NA)
 
     #
     # DataVector's
     #
 
     dv = DataArray([1, 2, 3], falses(3))
-    @assert isequal(dv.data, [1, 2, 3])
-    @assert isequal(dv.na, falses(3))
-    @assert isequal(dv, DataArray([1, 2, 3], [false, false, false]))
-    @assert isequal(dv, DataArray([1, 2, 3]))
+    @test isequal(dv.data, [1, 2, 3])
+    @test isequal(dv.na, falses(3))
+    @test isequal(dv, DataArray([1, 2, 3], [false, false, false]))
+    @test isequal(dv, DataArray([1, 2, 3]))
 
     dv = convert(DataArray, trues(3))
-    @assert isequal(dv.data, [true, true, true])
-    @assert isequal(dv.na, falses(3))
-    @assert isequal(dv, convert(DataArray, trues(3)))
+    @test isequal(dv.data, [true, true, true])
+    @test isequal(dv.na, falses(3))
+    @test isequal(dv, convert(DataArray, trues(3)))
 
     dv = DataArray([1, 2, 3], falses(3))
-    @assert isequal(dv, convert(DataArray, 1:3))
+    @test isequal(dv, convert(DataArray, 1:3))
 
     dv = DataArray(Int, 3)
-    @assert isequal(eltype(dv), Int)
-    @assert isequal(dv.na, trues(3))
+    @test isequal(eltype(dv), Int)
+    @test isequal(dv.na, trues(3))
 
     dv = convert(DataArray, zeros(3))
-    @assert isequal(dv, convert(DataArray, zeros(3)))
+    @test isequal(dv, convert(DataArray, zeros(3)))
 
     dv = convert(DataArray, zeros(Int, 3))
-    @assert isequal(dv, convert(DataArray, zeros(Int, 3)))
+    @test isequal(dv, convert(DataArray, zeros(Int, 3)))
 
     dv = convert(DataArray, ones(3))
-    @assert isequal(dv, convert(DataArray, ones(3)))
+    @test isequal(dv, convert(DataArray, ones(3)))
 
     dv = convert(DataArray, ones(Int, 3))
-    @assert isequal(dv, convert(DataArray, ones(Int, 3)))
+    @test isequal(dv, convert(DataArray, ones(Int, 3)))
 
     dv = convert(DataArray, falses(3))
-    @assert isequal(dv, convert(DataArray, falses(3)))
+    @test isequal(dv, convert(DataArray, falses(3)))
 
     dv = convert(DataArray, trues(3))
-    @assert isequal(dv, convert(DataArray, trues(3)))
+    @test isequal(dv, convert(DataArray, trues(3)))
 
     #
     # PooledDataArray's
     #
 
     pdv = PooledDataArray([1, 2, 3], falses(3))
-    @assert all(pdv .== [1, 2, 3])
-    @assert all(isna(pdv) .== falses(3))
+    @test all(pdv .== [1, 2, 3])
+    @test all(isna(pdv) .== falses(3))
 
-    @assert isequal(pdv, PooledDataArray([1, 2, 3], [false, false, false]))
-    @assert isequal(pdv, PooledDataArray([1, 2, 3]))
+    @test isequal(pdv, PooledDataArray([1, 2, 3], [false, false, false]))
+    @test isequal(pdv, PooledDataArray([1, 2, 3]))
 
     pdv = convert(PooledDataArray, trues(3))
-    @assert all(pdv .== [true, true, true])
-    @assert all(isna(pdv) .== falses(3))
-    @assert isequal(pdv, convert(PooledDataArray, trues(3)))
+    @test all(pdv .== [true, true, true])
+    @test all(isna(pdv) .== falses(3))
+    @test isequal(pdv, convert(PooledDataArray, trues(3)))
 
     pdv = PooledDataArray([1, 2, 3], falses(3))
-    @assert isequal(pdv, convert(PooledDataArray, 1:3))
-    @assert isequal(pdv, convert(PooledDataArray, PooledDataArray([1, 2, 3])))
+    @test isequal(pdv, convert(PooledDataArray, 1:3))
+    @test isequal(pdv, convert(PooledDataArray, PooledDataArray([1, 2, 3])))
 
     pdv = PooledDataArray(Int, 3)
-    @assert isequal(eltype(pdv), Int)
-    @assert all(isna(pdv) .== trues(3))
+    @test isequal(eltype(pdv), Int)
+    @test all(isna(pdv) .== trues(3))
 
     pdv = convert(PooledDataArray, zeros(3))
-    @assert isequal(pdv, convert(PooledDataArray, zeros(3)))
+    @test isequal(pdv, convert(PooledDataArray, zeros(3)))
 
     pdv = convert(PooledDataArray, zeros(Int, 3))
-    @assert isequal(pdv, convert(PooledDataArray, zeros(Int, 3)))
+    @test isequal(pdv, convert(PooledDataArray, zeros(Int, 3)))
 
     pdv = convert(PooledDataArray, ones(3))
-    @assert isequal(pdv, convert(PooledDataArray, ones(3)))
+    @test isequal(pdv, convert(PooledDataArray, ones(3)))
 
     pdv = convert(PooledDataArray, ones(Int, 3))
-    @assert isequal(pdv, convert(PooledDataArray, ones(Int, 3)))
+    @test isequal(pdv, convert(PooledDataArray, ones(Int, 3)))
 
     pdv = convert(PooledDataArray, falses(3))
-    @assert isequal(pdv, convert(PooledDataArray, falses(3)))
+    @test isequal(pdv, convert(PooledDataArray, falses(3)))
 
     pdv = convert(PooledDataArray, trues(3))
-    @assert isequal(pdv, convert(PooledDataArray, trues(3)))
+    @test isequal(pdv, convert(PooledDataArray, trues(3)))
 
     #
     # DataMatrix
     #
 
     dm = DataArray([1 2; 3 4], falses(2, 2))
-    @assert isequal(dm.data, [1 2; 3 4])
-    @assert isequal(dm.na, falses(2, 2))
+    @test isequal(dm.data, [1 2; 3 4])
+    @test isequal(dm.na, falses(2, 2))
 
-    @assert isequal(dm, DataArray([1 2; 3 4], [false false; false false]))
-    @assert isequal(dm, DataArray([1 2; 3 4]))
+    @test isequal(dm, DataArray([1 2; 3 4], [false false; false false]))
+    @test isequal(dm, DataArray([1 2; 3 4]))
 
     dm = convert(DataArray, trues(2, 2))
-    @assert isequal(dm.data, trues(2, 2))
-    @assert isequal(dm.na, falses(2, 2))
+    @test isequal(dm.data, trues(2, 2))
+    @test isequal(dm.na, falses(2, 2))
 
-    @assert isequal(dm, convert(DataArray, trues(2, 2)))
+    @test isequal(dm, convert(DataArray, trues(2, 2)))
 
     dm = DataArray(Int, 2, 2)
-    @assert isequal(eltype(dm), Int)
-    @assert isequal(dm.na, trues(2, 2))
+    @test isequal(eltype(dm), Int)
+    @test isequal(dm.na, trues(2, 2))
 
-    convert(DataArray, zeros(2, 2))
+    @test_nowarn convert(DataArray, zeros(2, 2))
 
-    convert(DataArray, zeros(Int, 2, 2))
+    @test_nowarn convert(DataArray, zeros(Int, 2, 2))
 
-    convert(DataArray, ones(2, 2))
-    convert(DataArray, ones(Int, 2, 2))
+    @test_nowarn convert(DataArray, ones(2, 2))
+    @test_nowarn convert(DataArray, ones(Int, 2, 2))
 
-    convert(DataArray, falses(2, 2))
-    convert(DataArray, trues(2, 2))
+    @test_nowarn convert(DataArray, falses(2, 2))
+    @test_nowarn convert(DataArray, trues(2, 2))
 
-    convert(DataArray, eye(3, 2))
-    convert(DataArray, eye(2))
-    convert(DataArray, diagm(Float64[pi, pi]))
+    @test_nowarn convert(DataArray, eye(3, 2))
+    @test_nowarn convert(DataArray, eye(2))
+    @test_nowarn convert(DataArray, diagm(Float64[pi, pi]))
 end

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -1,68 +1,64 @@
-module TestContainers
-using Base.Test
-using DataArrays
+@testset "Containers" begin
+    dv = @data ones(3)
+    push!(dv, 3.0)
+    push!(dv, NA)
 
-dv = @data ones(3)
-push!(dv, 3.0)
-push!(dv, NA)
+    @test isequal(dv, (@data [1.0, 1.0, 1.0, 3.0, NA]))
 
-@assert isequal(dv, (@data [1.0, 1.0, 1.0, 3.0, NA]))
+    a, b = pop!(dv), pop!(dv)
+    @test isna(a)
+    @test b == 3.0
 
-a, b = pop!(dv), pop!(dv)
-@assert isna(a)
-@assert b == 3.0
+    unshift!(dv, 3.0)
+    unshift!(dv, NA)
 
-unshift!(dv, 3.0)
-unshift!(dv, NA)
+    @test isequal(dv, (@data [NA, 3.0, 1.0, 1.0, 1.0]))
 
-@assert isequal(dv, (@data [NA, 3.0, 1.0, 1.0, 1.0]))
+    a, b = shift!(dv), shift!(dv)
+    @test isna(a)
+    @test b == 3.0
 
-a, b = shift!(dv), shift!(dv)
-@assert isna(a)
-@assert b == 3.0
-
-## SPLICE
-function test_splice(dv, spliceout, splicein...)
-    dv = copy(dv)
-    v = Any[x for x in dv]
-    expval = dv[spliceout]
-    retval = splice!(dv, spliceout, splicein...)
-    isequal(retval, expval) ||
-        error("splice!$(tuple(dv, spliceout, splicein...)) gave incorrect return value $retval (expected $expval)")
-    splice!(v, spliceout, splicein...)
-    for i = 1:length(v)
-        isequal(dv[i], v[i]) ||
-            error("splice!$(tuple(dv, spliceout, splicein...)) gave incorrect output")
-    end
-end
-
-function test_deleteat(dv, spliceout)
-    dv = copy(dv)
-    v = Any[x for x in dv]
-    @test deleteat!(dv, spliceout) === dv
-    deleteat!(v, spliceout)
-    for i = 1:length(v)
-        isequal(dv[i], v[i]) ||
-            error("deleteat!($(tuple(dv, spliceout)) gave incorrect output")
-    end
-end
-
-dv1 = @data [1.0, 2.0, NA, 2.0, NA, 3.0]
-for dv in (dv1, convert(DataVector{Number}, dv1), convert(PooledDataArray, dv1))
-    for spliceout in (2, 3, 2:3, 5:6)
-        test_splice(dv, spliceout)
-        test_deleteat(dv, spliceout)
-        for splicein in ([], [3], @data([3]), @pdata([3]),
-                         [3, 4, 5], [3., 4., 5.], @data([3, NA, 4]),
-                         @pdata([3, NA, 4]), @data([NA, 3.0, 4.0]),
-                         @pdata([NA, 3.0, 4.0]))
-            test_splice(dv, spliceout, splicein)
+    ## SPLICE
+    function test_splice(dv, spliceout, splicein...)
+        dv = copy(dv)
+        v = Any[x for x in dv]
+        expval = dv[spliceout]
+        retval = splice!(dv, spliceout, splicein...)
+        isequal(retval, expval) ||
+            error("splice!$(tuple(dv, spliceout, splicein...)) gave incorrect return value $retval (expected $expval)")
+        splice!(v, spliceout, splicein...)
+        for i = 1:length(v)
+            isequal(dv[i], v[i]) ||
+                error("splice!$(tuple(dv, spliceout, splicein...)) gave incorrect output")
         end
     end
-end
 
-## sizehint
-sizehint!(@data([1.0, 2.0]), 5)
-sizehint!(@pdata([1.0, 2.0]), 5)
+    function test_deleteat(dv, spliceout)
+        dv = copy(dv)
+        v = Any[x for x in dv]
+        @test deleteat!(dv, spliceout) === dv
+        deleteat!(v, spliceout)
+        for i = 1:length(v)
+            isequal(dv[i], v[i]) ||
+                error("deleteat!($(tuple(dv, spliceout)) gave incorrect output")
+        end
+    end
 
+    dv1 = @data [1.0, 2.0, NA, 2.0, NA, 3.0]
+    for dv in (dv1, convert(DataVector{Number}, dv1), convert(PooledDataArray, dv1))
+        for spliceout in (2, 3, 2:3, 5:6)
+            test_splice(dv, spliceout)
+            test_deleteat(dv, spliceout)
+            for splicein in ([], [3], @data([3]), @pdata([3]),
+                             [3, 4, 5], [3., 4., 5.], @data([3, NA, 4]),
+                             @pdata([3, NA, 4]), @data([NA, 3.0, 4.0]),
+                             @pdata([NA, 3.0, 4.0]))
+                test_splice(dv, spliceout, splicein)
+            end
+        end
+    end
+
+    ## sizehint
+    sizehint!(@data([1.0, 2.0]), 5)
+    sizehint!(@pdata([1.0, 2.0]), 5)
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,20 +1,17 @@
-module TestConversions
-    using Base.Test
-    using DataArrays
-
-    @assert isequal(@data([1, 2, NA]),
-                    convert(DataArray, @pdata([1, 2, NA])))
+@testset "Conversions" begin
+    @test isequal(@data([1, 2, NA]),
+                  convert(DataArray, @pdata([1, 2, NA])))
 
     # Test vector() and matrix() conversion tools
     dv = @data ones(5)
-    @assert isa(convert(Vector{Float64}, dv), Vector{Float64})
+    @test isa(convert(Vector{Float64}, dv), Vector{Float64})
     dv[1] = NA
     # Should raise errors:
     # vector(dv)
     # convert(Vector{Float64}, dv)
 
     dm = @data ones(3, 3)
-    @assert isa(convert(Matrix{Float64}, dm), Matrix{Float64})
+    @test isa(convert(Matrix{Float64}, dm), Matrix{Float64})
     dm[1, 1] = NA
     # Should raise errors:
     # matrix(dm)

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,17 +1,11 @@
-module TestData
-    using Base.Test
-    using DataArrays
-    using Compat
-    import Compat.String
-
-    #test_context("Data types and NA's")
-
+@testset "Data types and NA's" begin
+    # TODO: Convert these test_group things to nested testsets
     #test_group("NA's")
-    @assert length(NA) == 1
-    @assert size(NA) == ()
-    @assert isna(3 == NA)
-    @assert isna(NA == 3)
-    @assert isna(NA == NA)
+    @test length(NA) == 1
+    @test size(NA) == ()
+    @test isna(3 == NA)
+    @test isna(NA == 3)
+    @test isna(NA == NA)
 
     #test_group("DataVector creation")
     dvint = @data [1, 2, NA, 4]
@@ -22,166 +16,166 @@ module TestData
     dvdict = DataArray(Dict, 4) # for issue #199
     dvany = convert(DataArray{Any, 1}, dvint)
 
-    @assert isa(dvint, DataVector{Int})
-    @assert isa(dvint2, DataVector{Int})
-    @assert isa(dvint3, DataVector{Int})
-    @assert isa(dvflt, DataVector{Float64})
-    @assert isa(dvstr, DataVector{String})
+    @test isa(dvint, DataVector{Int})
+    @test isa(dvint2, DataVector{Int})
+    @test isa(dvint3, DataVector{Int})
+    @test isa(dvflt, DataVector{Float64})
+    @test isa(dvstr, DataVector{String})
     @test_throws ArgumentError DataArray([5:8], falses(2))
 
     #test_group("PooledDataVector creation")
     pdvstr = @pdata ["one", "one", "two", "two", NA, "one", "one"]
-    @assert isa(pdvstr, PooledDataVector{String})
-    @assert isequal(PooledDataArray(pdvstr), pdvstr)
+    @test isa(pdvstr, PooledDataVector{String})
+    @test isequal(PooledDataArray(pdvstr), pdvstr)
 
     #test_group("PooledDataVector creation with predetermined pool")
     pdvpp = PooledDataArray([1, 2, 2, 3], [1, 2, 3, 4])
-    @assert isequal(pdvpp.pool, [1, 2, 3, 4])
-    @assert string(pdvpp) == "[1, 2, 2, 3]"
+    @test isequal(pdvpp.pool, [1, 2, 3, 4])
+    @test string(pdvpp) == "[1, 2, 2, 3]"
     pdvpp = PooledDataArray([1, 2, 2, 3, 2, 1], [1, 2, 3, 4])
-    @assert isequal(pdvpp.pool, [1, 2, 3, 4])
-    @assert string(pdvpp) == "[1, 2, 2, 3, 2, 1]"
+    @test isequal(pdvpp.pool, [1, 2, 3, 4])
+    @test string(pdvpp) == "[1, 2, 2, 3, 2, 1]"
     pdvpp = PooledDataArray(["one", "two", "two"], ["one", "two", "three"])
-    @assert isequal(convert(DataArray, pdvpp), @data(["one", "two", "two"]))
-    @assert isequal(levels(pdvpp), @data(["one", "two", "three"]))
-    @assert isequal(pdvpp.pool, ["one", "two", "three"])
-    @assert string(pdvpp) == "[one, two, two]"
-    @assert string(PooledDataArray(["one", "two", "four"],
+    @test isequal(convert(DataArray, pdvpp), @data(["one", "two", "two"]))
+    @test isequal(levels(pdvpp), @data(["one", "two", "three"]))
+    @test isequal(pdvpp.pool, ["one", "two", "three"])
+    @test string(pdvpp) == "[one, two, two]"
+    @test string(PooledDataArray(["one", "two", "four"],
                                    ["one", "two", "three"])) ==
             "[one, two, NA]"
 
     #test_group("PooledDataVector utf8 support")
     pdvpp = PooledDataArray([String("hello")], [false])
-    @assert isa(pdvpp[1], String)
+    @test isa(pdvpp[1], String)
     pdvpp = PooledDataArray([String("hello")])
-    @assert isa(pdvpp[1], String)
+    @test isa(pdvpp[1], String)
 
     #test_group("DataVector access")
-    @assert dvint[1] == 1
-    @assert isna(dvint[3])
-    @assert isequal(dvflt[3:4], @data([NA, 4.0]))
-    @assert isequal(dvint[[true, false, true, false]], @data([1, NA]))
-    @assert isequal(dvstr[[1, 2, 1, 4]], @data(["one", "two", "one", "four"]))
+    @test dvint[1] == 1
+    @test isna(dvint[3])
+    @test isequal(dvflt[3:4], @data([NA, 4.0]))
+    @test isequal(dvint[[true, false, true, false]], @data([1, NA]))
+    @test isequal(dvstr[[1, 2, 1, 4]], @data(["one", "two", "one", "four"]))
     # Indexing produces #undef?
-    # @assert isequal(dvstr[[1, 2, 1, 3]], DataVector["one", "two", "one", NA])
+    # @test isequal(dvstr[[1, 2, 1, 3]], DataVector["one", "two", "one", NA])
 
     #test_group("PooledDataVector access")
-    @assert pdvstr[1] == "one"
-    @assert isna(pdvstr[5])
-    @assert isequal(pdvstr[1:3], @data(["one", "one", "two"]))
-    @assert isequal(pdvstr[[true, false, true, false, true, false, true]],
+    @test pdvstr[1] == "one"
+    @test isna(pdvstr[5])
+    @test isequal(pdvstr[1:3], @data(["one", "one", "two"]))
+    @test isequal(pdvstr[[true, false, true, false, true, false, true]],
                     @pdata(["one", "two", NA, "one"]))
-    @assert isequal(pdvstr[[1, 3, 1, 2]], @data(["one", "two", "one", "one"]))
+    @test isequal(pdvstr[[1, 3, 1, 2]], @data(["one", "two", "one", "one"]))
 
     #test_group("DataVector methods")
-    @assert size(dvint) == (4,)
-    @assert length(dvint) == 4
-    @assert sum(isna(dvint)) == 1
-    @assert eltype(dvint) == Int
+    @test size(dvint) == (4,)
+    @test length(dvint) == 4
+    @test sum(isna(dvint)) == 1
+    @test eltype(dvint) == Int
 
     #test_group("PooledDataVector methods")
-    @assert size(pdvstr) == (7,)
-    @assert length(pdvstr) == 7
-    @assert sum(isna(pdvstr)) == 1
-    @assert eltype(pdvstr) == String
+    @test size(pdvstr) == (7,)
+    @test length(pdvstr) == 7
+    @test sum(isna(pdvstr)) == 1
+    @test eltype(pdvstr) == String
 
     #test_group("DataVector operations")
-    @assert isequal(dvint .+ 1, DataArray([2, 3, 4, 5], [false, false, true, false]))
-    @assert isequal(dvint .* 2, @data([2, 4, NA, 8]))
-    @assert isequal(dvint .== 2, @data([false, true, NA, false]))
-    @assert isequal(dvint .> 1, @data([false, true, NA, true]))
+    @test isequal(dvint .+ 1, DataArray([2, 3, 4, 5], [false, false, true, false]))
+    @test isequal(dvint .* 2, @data([2, 4, NA, 8]))
+    @test isequal(dvint .== 2, @data([false, true, NA, false]))
+    @test isequal(dvint .> 1, @data([false, true, NA, true]))
 
     #test_group("PooledDataVector operations")
-    # @assert isequal(pdvstr .== "two", PooledDataVector[false, false, true, true, NA, false, false])
+    # @test isequal(pdvstr .== "two", PooledDataVector[false, false, true, true, NA, false, false])
 
     #test_group("DataVector to something else")
-    @assert all(dropna(dvint) .== [1, 2, 4])
-    @assert all(convert(Vector, dvint, 0) .== [1, 2, 0, 4])
-    @assert all(convert(Vector, dvany, 0) .== [1, 2, 0, 4])
+    @test all(dropna(dvint) .== [1, 2, 4])
+    @test all(convert(Vector, dvint, 0) .== [1, 2, 0, 4])
+    @test all(convert(Vector, dvany, 0) .== [1, 2, 0, 4])
     utf8three = convert(String, "three")
     asciithree = convert(String, "three")
-    @assert all(convert(Vector, dvstr, utf8three) .== ["one", "two", "three", "four"])
-    @assert all(convert(Vector, dvstr, asciithree) .== ["one", "two", "three", "four"])
-    @assert all(convert(Vector{Int}, dvint2) .== [5:8;])
-    @assert all([i + 1 for i in dvint2] .== [6:9;])
-    @assert all([length(x)::Int for x in dvstr] == [3, 3, 1, 4])
-    @assert repr(dvint) == "[1, 2, NA, 4]"
+    @test all(convert(Vector, dvstr, utf8three) .== ["one", "two", "three", "four"])
+    @test all(convert(Vector, dvstr, asciithree) .== ["one", "two", "three", "four"])
+    @test all(convert(Vector{Int}, dvint2) .== [5:8;])
+    @test all([i + 1 for i in dvint2] .== [6:9;])
+    @test all([length(x)::Int for x in dvstr] == [3, 3, 1, 4])
+    @test repr(dvint) == "[1, 2, NA, 4]"
 
     #test_group("PooledDataVector to something else")
-    @assert all(dropna(pdvstr) .== ["one", "one", "two", "two", "one", "one"])
-    @assert all(convert(Vector, pdvstr, "nine") .== ["one", "one", "two", "two", "nine", "one", "one"])
-    @assert all([length(i)::Int for i in pdvstr] .== [3, 3, 3, 3, 1, 3, 3])
-    @assert string(pdvstr[1:3]) == "[one, one, two]"
+    @test all(dropna(pdvstr) .== ["one", "one", "two", "two", "one", "one"])
+    @test all(convert(Vector, pdvstr, "nine") .== ["one", "one", "two", "two", "nine", "one", "one"])
+    @test all([length(i)::Int for i in pdvstr] .== [3, 3, 3, 3, 1, 3, 3])
+    @test string(pdvstr[1:3]) == "[one, one, two]"
 
     #test_group("DataVector Filter and Replace")
-    @assert isequal(dropna(dvint), [1, 2, 4])
-    @assert isequal(convert(Vector, dvint, 7), [1, 2, 7, 4])
-    @assert sum(dropna(dvint)) == 7
-    @assert sum(convert(Vector, dvint, 7)) == 14
+    @test isequal(dropna(dvint), [1, 2, 4])
+    @test isequal(convert(Vector, dvint, 7), [1, 2, 7, 4])
+    @test sum(dropna(dvint)) == 7
+    @test sum(convert(Vector, dvint, 7)) == 14
 
     #test_group("PooledDataVector Filter and Replace")
-    @assert reduce(string, "", dropna(pdvstr)) == "oneonetwotwooneone"
-    @assert reduce(string, "", convert(Vector, pdvstr, "!")) == "oneonetwotwo!oneone"
+    @test reduce(string, "", dropna(pdvstr)) == "oneonetwotwooneone"
+    @test reduce(string, "", convert(Vector, pdvstr, "!")) == "oneonetwotwo!oneone"
 
     #test_group("DataVector assignment")
     assigntest = @data [1, 2, NA, 4]
     assigntest[1] = 8
-    @assert isequal(assigntest, (@data [8, 2, NA, 4]))
+    @test isequal(assigntest, (@data [8, 2, NA, 4]))
     assigntest[1:2] = 9
-    @assert isequal(assigntest, (@data [9, 9, NA, 4]))
+    @test isequal(assigntest, (@data [9, 9, NA, 4]))
     assigntest[[1,3]] = 10
-    @assert isequal(assigntest, (@data [10, 9, 10, 4]))
+    @test isequal(assigntest, (@data [10, 9, 10, 4]))
     assigntest[[true, false, true, true]] = 11
-    @assert isequal(assigntest, (@data [11, 9, 11, 11]))
+    @test isequal(assigntest, (@data [11, 9, 11, 11]))
     assigntest[1:2] = [12, 13]
-    @assert isequal(assigntest, (@data [12, 13, 11, 11]))
+    @test isequal(assigntest, (@data [12, 13, 11, 11]))
     assigntest[[1, 4]] = [14, 15]
-    @assert isequal(assigntest, (@data [14, 13, 11, 15]))
+    @test isequal(assigntest, (@data [14, 13, 11, 15]))
     assigntest[[true, false, true, false]] = [16, 17]
-    @assert isequal(assigntest, (@data [16, 13, 17, 15]))
+    @test isequal(assigntest, (@data [16, 13, 17, 15]))
     assigntest[1] = NA
-    @assert isequal(assigntest, (@data [NA, 13, 17, 15]))
+    @test isequal(assigntest, (@data [NA, 13, 17, 15]))
     assigntest[[1, 2]] = NA
-    @assert isequal(assigntest, (@data [NA, NA, 17, 15]))
+    @test isequal(assigntest, (@data [NA, NA, 17, 15]))
     assigntest[[true, false, true, false]] = NA
-    @assert isequal(assigntest, (@data [NA, NA, NA, 15]))
+    @test isequal(assigntest, (@data [NA, NA, NA, 15]))
     assigntest[1] = 1
     assigntest[2:4] = NA
-    @assert isequal(assigntest, (@data [1, NA, NA, NA]))
+    @test isequal(assigntest, (@data [1, NA, NA, NA]))
 
     #test_group("PooledDataVector assignment")
     ret = (pdvstr[2] = "three")
-    @assert ret == "three"
-    @assert pdvstr[2] == "three"
+    @test ret == "three"
+    @test pdvstr[2] == "three"
     ret = pdvstr[[1,2]] = "two"
-    @assert ret == "two"
-    @assert pdvstr[2] == "two"
+    @test ret == "two"
+    @test pdvstr[2] == "two"
     pdvstr2 = @pdata ["one", "one", "two", "two"]
     ret = (pdvstr2[[true, false, true, false]] = "three")
-    @assert ret == "three"
-    @assert pdvstr2[1] == "three"
+    @test ret == "three"
+    @test pdvstr2[1] == "three"
     ret = (pdvstr2[[false, true, false, true]] = ["four", "five"])
-    @assert isequal(ret, ["four", "five"])
-    @assert isequal(pdvstr2[3:4], (@data ["three", "five"]))
+    @test isequal(ret, ["four", "five"])
+    @test isequal(pdvstr2[3:4], (@data ["three", "five"]))
     pdvstr2 = @pdata ["one", "one", "two", "two"]
     ret = (pdvstr2[2:3] = "three")
-    @assert ret == "three"
-    @assert isequal(pdvstr2[3:4], (@data ["three", "two"]))
+    @test ret == "three"
+    @test isequal(pdvstr2[3:4], (@data ["three", "two"]))
     ret = (pdvstr2[2:3] = ["four", "five"])
-    @assert ret == ["four", "five"]
-    @assert isequal(pdvstr2[1:2], (@data ["one", "four"]))
+    @test ret == ["four", "five"]
+    @test isequal(pdvstr2[1:2], (@data ["one", "four"]))
     pdvstr2 = @pdata ["one", "one", "two", "two", "three"]
-    @assert isna(begin pdvstr2[1] = NA end)
-    @assert all(isna(begin pdvstr2[[1, 2]] = NA end))
-    @assert all(isna(begin pdvstr2[[false, false, true, false, false]] = NA end))
-    @assert all(isna(begin pdvstr2[4:5] = NA end))
-    @assert all(isna(pdvstr2))
+    @test isna(begin pdvstr2[1] = NA end)
+    @test all(isna(begin pdvstr2[[1, 2]] = NA end))
+    @test all(isna(begin pdvstr2[[false, false, true, false, false]] = NA end))
+    @test all(isna(begin pdvstr2[4:5] = NA end))
+    @test all(isna(pdvstr2))
 
     #test_group("PooledDataVector replace!")
     pdvstr2 = @pdata ["one", "one", "two", "two", "three"]
-    @assert replace!(pdvstr2, "two", "four") == "four"
-    @assert replace!(pdvstr2, "three", "four") == "four"
-    @assert isna(replace!(pdvstr2, "one", NA))
-    @assert replace!(pdvstr2, NA, "five") == "five"
-    @assert isequal(pdvstr2, (@data ["five", "five", "four", "four", "four"]))
+    @test replace!(pdvstr2, "two", "four") == "four"
+    @test replace!(pdvstr2, "three", "four") == "four"
+    @test isna(replace!(pdvstr2, "one", NA))
+    @test replace!(pdvstr2, NA, "five") == "five"
+    @test isequal(pdvstr2, (@data ["five", "five", "four", "four", "four"]))
 end

--- a/test/dataarray.jl
+++ b/test/dataarray.jl
@@ -1,7 +1,4 @@
-module TestDataArray
-    using Base.Test
-    using DataArrays
-
+@testset "DataArray" begin
     v = [1, 2, 3, 4]
     dv = DataArray(v, falses(size(v)))
 
@@ -33,11 +30,11 @@ module TestDataArray
 
     x = DataArray([9, 9, 8])
     y = DataArray([1, 9, 3, 2, 2])
-    @assert append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
+    @test append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
 
     x = DataArray([9, 9, 8])
     y = [1, 9, 3, 2, 2]
-    @assert append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
+    @test append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
 
     x = @data [1, 2, NA]
     y = @data [3, NA, 5]
@@ -45,15 +42,15 @@ module TestDataArray
     @test isequal(copy!(y, x), x)
 
     x = @data [1, NA, -2, 1, NA, 4]
-    @assert isequal(unique(x), @data [1, NA, -2, 4])
-    @assert isequal(unique(reverse(x)), @data [4, NA, 1, -2])
-    @assert isequal(unique(dropna(x)), @data [1, -2, 4])
-    @assert isequal(unique(reverse(dropna(x))), @data [4, 1, -2])
-    @assert isequal(levels(x), @data [1, -2, 4])
-    @assert isequal(levels(reverse(x)), @data [4, 1, -2])
+    @test isequal(unique(x), @data [1, NA, -2, 4])
+    @test isequal(unique(reverse(x)), @data [4, NA, 1, -2])
+    @test isequal(unique(dropna(x)), @data [1, -2, 4])
+    @test isequal(unique(reverse(dropna(x))), @data [4, 1, -2])
+    @test isequal(levels(x), @data [1, -2, 4])
+    @test isequal(levels(reverse(x)), @data [4, 1, -2])
 
     # check case where only NA occurs in final position
-    @assert isequal(unique(@data [1, 2, 1, NA]), @data [1, 2, NA])
+    @test isequal(unique(@data [1, 2, 1, NA]), @data [1, 2, NA])
 
     # Test copy!
     function nonbits(dv)
@@ -72,7 +69,6 @@ module TestDataArray
     set3 = map(pdata, set1)
 
     for (dest, src, bigsrc, emptysrc, res1, res2) in Any[set1, set2, set3]
-
         @test isequal(copy!(copy(dest), src), res1)
         @test isequal(copy!(copy(dest), 1, src), res1)
 
@@ -101,5 +97,4 @@ module TestDataArray
         @test_throws BoundsError copy!(dest, 3, src, 1, 2)
         @test_throws BoundsError copy!(dest, 1, src, 2, 2)
     end
-
 end

--- a/test/datamatrix.jl
+++ b/test/datamatrix.jl
@@ -1,7 +1,4 @@
-module TestDataMatrix
-    using Base.Test
-    using DataArrays
-
+@testset "DataMatrix" begin
     a = @data [1.0, 2.0, 3.0]
     v_a = [1.0, 2.0, 3.0]
 
@@ -12,30 +9,30 @@ module TestDataMatrix
     # Transposes
     #
 
-    @assert all(a' .== v_a')
-    @assert all(a'' .== v_a'')
-    @assert all(b' .== m_b')
-    @assert all(b'' .== m_b'')
+    @test all(a' .== v_a')
+    @test all(a'' .== v_a'')
+    @test all(b' .== m_b')
+    @test all(b'' .== m_b'')
 
     #
     # DataVector * DataMatrix
     #
 
     # TODO: Get indexing for b[1, :] to work
-    # @assert all(a * b[1, :] .== v_a * m_b[1, :])
+    # @test all(a * b[1, :] .== v_a * m_b[1, :])
 
     #
     # DataMatrix * DataVector
     #
 
-    @assert all(b * a .== m_b * v_a)
-    @assert all(convert(Array, b * a) .== m_b * v_a)
+    @test all(b * a .== m_b * v_a)
+    @test all(convert(Array, b * a) .== m_b * v_a)
 
     #
     # DataMatrix * DataMatrix
     #
 
-    @assert all(b * b .== m_b * m_b)
+    @test all(b * b .== m_b * m_b)
 
     #
     # DataVector * DataMatrix w/ NA's
@@ -43,20 +40,20 @@ module TestDataMatrix
 
     b[1, 1] = NA
     res = a * b[1:1, :]
-    @assert all(isna(res[:, 1]))
-    @assert all(.!(isna(res[:, 2])))
-    @assert all(.!(isna(res[:, 3])))
+    @test all(isna(res[:, 1]))
+    @test all(.!(isna(res[:, 2])))
+    @test all(.!(isna(res[:, 3])))
     res = a * b[2:2, :]
-    @assert all(.!(isna(res)))
+    @test all(.!(isna(res)))
 
     #
     # DataMatrix w NA's * DataVector
     #
 
     res = b * a
-    @assert isna(res[1])
-    @assert .!(isna(res[2]))
-    @assert .!(isna(res[3]))
+    @test isna(res[1])
+    @test .!(isna(res[2]))
+    @test .!(isna(res[3]))
 
     #
     # DataMatrix * DataMatrix
@@ -67,30 +64,30 @@ module TestDataMatrix
     #  NA   NA   NA
     #  NA  1.0  0.0
     #  NA  0.0  1.0
-    @assert isna(res[1, 1])
-    @assert isna(res[1, 2])
-    @assert isna(res[1, 3])
-    @assert isna(res[2, 1])
-    @assert .!(isna(res[2, 2]))
-    @assert .!(isna(res[2, 3]))
-    @assert isna(res[3, 1])
-    @assert .!(isna(res[3, 2]))
-    @assert .!(isna(res[3, 3]))
+    @test isna(res[1, 1])
+    @test isna(res[1, 2])
+    @test isna(res[1, 3])
+    @test isna(res[2, 1])
+    @test .!(isna(res[2, 2]))
+    @test .!(isna(res[2, 3]))
+    @test isna(res[3, 1])
+    @test .!(isna(res[3, 2]))
+    @test .!(isna(res[3, 3]))
 
     res = b * @data eye(3)
     # 3x3 Float64 DataMatrix:
     #   NA   NA   NA
     #  0.0  1.0  0.0
     #  0.0  0.0  1.0
-    @assert isna(res[1, 1])
-    @assert isna(res[1, 2])
-    @assert isna(res[1, 3])
-    @assert .!(isna(res[2, 1]))
-    @assert .!(isna(res[2, 2]))
-    @assert .!(isna(res[2, 3]))
-    @assert .!(isna(res[3, 1]))
-    @assert .!(isna(res[3, 2]))
-    @assert .!(isna(res[3, 3]))
+    @test isna(res[1, 1])
+    @test isna(res[1, 2])
+    @test isna(res[1, 3])
+    @test .!(isna(res[2, 1]))
+    @test .!(isna(res[2, 2]))
+    @test .!(isna(res[2, 3]))
+    @test .!(isna(res[3, 1]))
+    @test .!(isna(res[3, 2]))
+    @test .!(isna(res[3, 3]))
 
     res = (@data eye(3)) * b
     # julia> dataeye(3) * b
@@ -98,15 +95,15 @@ module TestDataMatrix
     #  NA  0.0  0.0
     #  NA  1.0  0.0
     #  NA  0.0  1.0
-    @assert isna(res[1, 1])
-    @assert .!(isna(res[1, 2]))
-    @assert .!(isna(res[1, 3]))
-    @assert isna(res[2, 1])
-    @assert .!(isna(res[2, 2]))
-    @assert .!(isna(res[2, 3]))
-    @assert isna(res[3, 1])
-    @assert .!(isna(res[3, 2]))
-    @assert .!(isna(res[3, 3]))
+    @test isna(res[1, 1])
+    @test .!(isna(res[1, 2]))
+    @test .!(isna(res[1, 3]))
+    @test isna(res[2, 1])
+    @test .!(isna(res[2, 2]))
+    @test .!(isna(res[2, 3]))
+    @test isna(res[3, 1])
+    @test .!(isna(res[3, 2]))
+    @test .!(isna(res[3, 3]))
 
     # Test row operations
     dm = @data eye(6, 2)
@@ -119,11 +116,11 @@ module TestDataMatrix
     # Test linear algebra
     du, dd, dv = svd((@data eye(3, 3)))
     u, d, v = svd(eye(3, 3))
-    @assert all(du .== u)
-    @assert all(dd .== d)
-    @assert all(dv .== v)
+    @test all(du .== u)
+    @test all(dd .== d)
+    @test all(dv .== v)
 
     # Test elementary functions
     dm = -(@data eye(5, 5))
-    @assert all(abs(dm) .== eye(5, 5))
+    @test all(abs(dm) .== eye(5, 5))
 end

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -1,9 +1,4 @@
-module TestExtras
-    using Base.Test
-    using DataArrays
-    using StatsBase
-    using Compat
-
+@testset "Extras" begin
     ##########
     ## countmap
     ##########
@@ -12,20 +7,20 @@ module TestExtras
     w = weights([1.1,2.2,3.3])
     cm = Dict{Union{Int, NAtype}, Int}([(NA, 1), (3, 2)])
     cmw = Dict{Union{Int, NAtype}, Real}([(NA, 1.1), (3, 5.5)])
-    @assert isequal(countmap(d), cm)
-    @assert isequal(countmap(d, w), cmw)
+    @test isequal(countmap(d), cm)
+    @test isequal(countmap(d, w), cmw)
 
     ##########
     ## cut
     ##########
 
-    @assert isequal(cut([2, 3, 5], [1, 3, 6]), PooledDataArray(["(1,3]", "(1,3]", "(3,6]"]))
-    @assert isequal(cut([2, 3, 5], [3, 6]), PooledDataArray(["[2,3]", "[2,3]", "(3,6]"]))
-    @assert isequal(cut([2, 3, 5, 6], [3, 6]), PooledDataArray(["[2,3]", "[2,3]", "(3,6]", "(3,6]"]))
-    @assert isequal(cut([1, 2, 4], [1, 3, 6]), PooledDataArray(["[1,3]", "[1,3]", "(3,6]"]))
-    @assert isequal(cut([1, 2, 4], [3, 6]), PooledDataArray(["[1,3]", "[1,3]", "(3,6]"]))
-    @assert isequal(cut([1, 2, 4], [3]), PooledDataArray(["[1,3]", "[1,3]", "(3,4]"]))
-    @assert isequal(cut([1, 5, 7], [3, 6]), PooledDataArray(["[1,3]", "(3,6]", "(6,7]"]))
+    @test isequal(cut([2, 3, 5], [1, 3, 6]), PooledDataArray(["(1,3]", "(1,3]", "(3,6]"]))
+    @test isequal(cut([2, 3, 5], [3, 6]), PooledDataArray(["[2,3]", "[2,3]", "(3,6]"]))
+    @test isequal(cut([2, 3, 5, 6], [3, 6]), PooledDataArray(["[2,3]", "[2,3]", "(3,6]", "(3,6]"]))
+    @test isequal(cut([1, 2, 4], [1, 3, 6]), PooledDataArray(["[1,3]", "[1,3]", "(3,6]"]))
+    @test isequal(cut([1, 2, 4], [3, 6]), PooledDataArray(["[1,3]", "[1,3]", "(3,6]"]))
+    @test isequal(cut([1, 2, 4], [3]), PooledDataArray(["[1,3]", "[1,3]", "(3,4]"]))
+    @test isequal(cut([1, 5, 7], [3, 6]), PooledDataArray(["[1,3]", "(3,6]", "(6,7]"]))
 
     ages = [20, 22, 25, 27, 21, 23, 37, 31, 61, 45, 41, 32]
     bins = [18, 25, 35, 60, 100]
@@ -34,7 +29,7 @@ module TestExtras
                            "(25,35]", "(18,25]", "(18,25]",
                            "(35,60]", "(25,35]", "(60,100]",
                            "(35,60]", "(35,60]", "(25,35]"])
-    @assert isequal(cats, pdv)
+    @test isequal(cats, pdv)
 
     ##########
     ## repeat

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,134 +1,131 @@
-module IndexingTests
-using DataArrays, Base.Test, Compat
+@testset "Indexing" begin
+    function run_tests(datype)
+        data = rand(10, 10)
+        na = bitrand(10, 10)
+        A = datype(data, na)
 
-function run_tests(datype)
-    data = rand(10, 10)
-    na = bitrand(10, 10)
-    A = datype(data, na)
-
-    # Scalar getindex
-    for i = 1:100
-        if na[i]
-            @test isna(A[i])
-        else
-            @test A[i] == data[i]
+        # Scalar getindex
+        for i = 1:100
+            if na[i]
+                @test isna(A[i])
+            else
+                @test A[i] == data[i]
+            end
         end
-    end
-    for i = 1:10, j = 1:10
-        if na[i, j]
-            @test isna(A[i, j])
-        else
-            @test A[i, j] == data[i, j]
-        end
-    end
-
-    # getindex with AbstractVectors
-    rg = 2:9
-    v = A[rg]
-    for i = 1:length(rg)
-        if na[rg[i]]
-            @test isna(v[i])
-        else
-            @test v[i] == data[rg[i]]
-        end
-    end
-
-    v = A[rg, 9]
-    for i = 1:length(rg)
-        if na[rg[i], 9]
-            @test isna(v[i])
-        else
-            @test v[i] == data[rg[i], 9]
-        end
-    end
-
-    rg2 = 5:7
-    v = A[rg, rg2]
-    for j = 1:length(rg2), i = 1:length(rg)
-        if na[rg[i], rg2[j]]
-            @test isna(v[i, j])
-        else
-            @test v[i, j] == data[rg[i], rg2[j]]
-        end
-    end
-
-    # getindex with AbstractVector{Bool}
-    b = bitrand(10, 10)
-    rg = find(b)
-    v = A[b]
-    for i = 1:length(rg)
-        if na[rg[i]]
-            @test isna(v[i])
-        else
-            @test v[i] == data[rg[i]]
-        end
-    end
-
-    # getindex with DataVectors with missingness throws
-    @test_throws NAException A[@data([1, 2, 3, NA])]
-
-    # setindex! with scalar indices
-    data = rand(10, 10)
-    for i = 1:100
-        A[i] = data[i]
-    end
-    @test A == data
-
-    data = rand(10, 10)
-    for i = 1:10, j = 1:10
-        A[i, j] = data[i, j]
-    end
-    @test A == data
-
-    na = bitrand(10, 10)
-    for i = 1:100
-        na[i] && (A[i] = NA)
-    end
-
-    # setindex! with scalar and vector indices
-    rg = 2:9
-    data[rg] = 1.0
-    A[rg] = 1.0
-    for i = 1:length(rg)
-        @test A[rg[i]] == 1.0
-    end
-
-    # setindex! with NA and vector indices
-    rg = 5:13
-    na[rg] = true
-    A[rg] = NA
-    for i = 1:length(rg)
-        @test isna(A[rg[i]])
-    end
-
-    # setindex! with vector and vector indices
-    rg = 12:67
-    data[rg] = rand(length(rg))
-    A[rg] = data[rg]
-    for i = 1:length(rg)
-        @test A[rg[i]] == data[rg[i]]
-    end
-
-    # setindex! with DataArray/PooledDataArray and vector indices
-    for datype2 in (DataArray, PooledDataArray)
-        newdata = rand(3, 3)
-        newdata[1:2:9] = data[1:2:9]
-        newna = bitrand(3, 3)
-        rg1, rg2 = 1:3, 5:7
-        data[rg1, rg2] = newdata
-        na[rg1, rg2] = newna
-        A[rg1, rg2] = datype2(newdata, newna)
-        for j = rg2, i = rg1
+        for i = 1:10, j = 1:10
             if na[i, j]
                 @test isna(A[i, j])
             else
                 @test A[i, j] == data[i, j]
             end
         end
+
+        # getindex with AbstractVectors
+        rg = 2:9
+        v = A[rg]
+        for i = 1:length(rg)
+            if na[rg[i]]
+                @test isna(v[i])
+            else
+                @test v[i] == data[rg[i]]
+            end
+        end
+
+        v = A[rg, 9]
+        for i = 1:length(rg)
+            if na[rg[i], 9]
+                @test isna(v[i])
+            else
+                @test v[i] == data[rg[i], 9]
+            end
+        end
+
+        rg2 = 5:7
+        v = A[rg, rg2]
+        for j = 1:length(rg2), i = 1:length(rg)
+            if na[rg[i], rg2[j]]
+                @test isna(v[i, j])
+            else
+                @test v[i, j] == data[rg[i], rg2[j]]
+            end
+        end
+
+        # getindex with AbstractVector{Bool}
+        b = bitrand(10, 10)
+        rg = find(b)
+        v = A[b]
+        for i = 1:length(rg)
+            if na[rg[i]]
+                @test isna(v[i])
+            else
+                @test v[i] == data[rg[i]]
+            end
+        end
+
+        # getindex with DataVectors with missingness throws
+        @test_throws NAException A[@data([1, 2, 3, NA])]
+
+        # setindex! with scalar indices
+        data = rand(10, 10)
+        for i = 1:100
+            A[i] = data[i]
+        end
+        @test A == data
+
+        data = rand(10, 10)
+        for i = 1:10, j = 1:10
+            A[i, j] = data[i, j]
+        end
+        @test A == data
+
+        na = bitrand(10, 10)
+        for i = 1:100
+            na[i] && (A[i] = NA)
+        end
+
+        # setindex! with scalar and vector indices
+        rg = 2:9
+        data[rg] = 1.0
+        A[rg] = 1.0
+        for i = 1:length(rg)
+            @test A[rg[i]] == 1.0
+        end
+
+        # setindex! with NA and vector indices
+        rg = 5:13
+        na[rg] = true
+        A[rg] = NA
+        for i = 1:length(rg)
+            @test isna(A[rg[i]])
+        end
+
+        # setindex! with vector and vector indices
+        rg = 12:67
+        data[rg] = rand(length(rg))
+        A[rg] = data[rg]
+        for i = 1:length(rg)
+            @test A[rg[i]] == data[rg[i]]
+        end
+
+        # setindex! with DataArray/PooledDataArray and vector indices
+        for datype2 in (DataArray, PooledDataArray)
+            newdata = rand(3, 3)
+            newdata[1:2:9] = data[1:2:9]
+            newna = bitrand(3, 3)
+            rg1, rg2 = 1:3, 5:7
+            data[rg1, rg2] = newdata
+            na[rg1, rg2] = newna
+            A[rg1, rg2] = datype2(newdata, newna)
+            for j = rg2, i = rg1
+                if na[i, j]
+                    @test isna(A[i, j])
+                else
+                    @test A[i, j] == data[i, j]
+                end
+            end
+        end
     end
-end
 
-run_tests(DataArray)
-run_tests(PooledDataArray)
-
+    run_tests(DataArray)
+    run_tests(PooledDataArray)
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,9 +1,6 @@
-module TestLinAlg
-    using Base.Test
-    using DataArrays
-
+@testset "LinAlg" begin
     d = @data eye(3, 3)
     d[1, 1] = NA
 
-    svd(d)
+    @test_nowarn svd(d)
 end

--- a/test/literals.jl
+++ b/test/literals.jl
@@ -1,8 +1,4 @@
-module TestLiterals
-    using Base.Test
-    using DataArrays
-    using Compat
-
+@testset "Literals" begin
     dv = @data []
     @test isequal(dv, DataArray([], Bool[]))
     @test typeof(dv) == DataVector{Any}

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -1,61 +1,57 @@
-module TestNAs
-    using Base.Test
-    using DataArrays
+@testset "NAs" begin
+    @testset "anyna(x)" begin
+        # anyna(a::AbstractArray)
+        @test anyna(Any[NA, 1])
+        @test !anyna([1, 2])
+        @test !anyna(repeat([1, 2], outer = [1, 2]))
+        @test !anyna(repeat([1, 2], outer = [1, 2, 2]))
 
+        # anyna(da::DataArray)
+        @test !anyna(DataArray([1, 2], falses(2)))
+        @test !anyna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
+        @test !anyna(da)
+        da[2] = NA
+        @test anyna(da)
 
-    # anyna(a::AbstractArray)
-    @test anyna(Any[NA, 1])
-    @test !anyna([1, 2])
-    anyna(repeat([1, 2], outer = [1, 2]))
-    @test !anyna(repeat([1, 2], outer = [1, 2, 2]))
+        # anyna(pda::PooledDataArray)
+        @test !anyna(PooledDataArray([1, 2], falses(2)))
+        @test !anyna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
+        @test !anyna(pda)
+        pda[2] = NA
+        @test anyna(pda)
+    end
 
-    # anyna(da::DataArray)
-    anyna(DataArray([1, 2], falses(2)))
-    anyna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-    da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-    @test !anyna(da)
-    da[2] = NA
-    @test anyna(da)
+    @testset "allna(x)" begin
+        # allna(a::AbstractArray)
+        @test allna(Any[NA, NA])
+        @test !allna(Any[NA, 1])
+        @test !allna([1, 2])
+        @test !allna(repeat([1, 2], outer = [1, 2]))
+        @test !allna(repeat([1, 2], outer = [1, 2, 2]))
 
-    # anyna(pda::PooledDataArray)
-    anyna(PooledDataArray([1, 2], falses(2)))
-    anyna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-    pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-    @test !anyna(pda)
-    pda[2] = NA
-    @test anyna(pda)
+        # allna(da::DataArray)
+        @test !allna(DataArray([1, 2], falses(2)))
+        @test !allna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
+        da[1] = NA
+        @test !allna(da)
+        da[:] = NA
+        @test allna(da)
 
-    # allna(a::AbstractArray)
-    @test allna(Any[NA, NA])
-    @test !allna(Any[NA, 1])
-    @test !allna([1, 2])
-    allna(repeat([1, 2], outer = [1, 2]))
-    @test !allna(repeat([1, 2], outer = [1, 2, 2]))
-
-    # allna(da::DataArray)
-    allna(DataArray([1, 2], falses(2)))
-    allna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-    da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-    da[1] = NA
-    @test !allna(da)
-    da[:] = NA
-    @test allna(da)
-
-    # allna(da::PooledDataArray)
-    allna(PooledDataArray([1, 2], falses(2)))
-    allna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
-    pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-    pda[1] = NA
-    @test !allna(pda)
-    pda[:] = NA
-    @test allna(pda)
-
-    dv = DataArray([1, 2, 3], BitArray([false, false, false]))
+        # allna(da::PooledDataArray)
+        @test !allna(PooledDataArray([1, 2], falses(2)))
+        @test !allna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
+        pda[1] = NA
+        @test !allna(pda)
+        pda[:] = NA
+        @test allna(pda)
+    end
 
     dv = DataArray(collect(1:6), fill(false, 6))
-
     a = dropna(dv)
-    for v in each_failna(dv); end
     @test collect(each_failna(dv)) == a
     @test collect(each_dropna(dv)) == a
     @test collect(each_replacena(dv, 4)) == a

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -1,7 +1,4 @@
-module TestOperators
-    using Base.Test
-    using DataArrays, StatsBase
-
+@testset "Operators" begin
     const bit_operators = [:(&),:(|),:(⊻)]
 
     const arithmetic_operators = [:(+),:(-),:(*),:(/), :(Base.div), :(Base.mod), :(Base.fld), :(Base.rem)]
@@ -38,10 +35,7 @@ module TestOperators
                                   :(exponent),
                                   :(sqrt),
                                   :(gamma),
-                                  :(lgamma),
-                                  :(digamma),
-                                  :(erf),
-                                  :(erfc)]
+                                  :(lgamma)]
 
     macro test_da_pda(da, code)
         esc(quote
@@ -55,40 +49,40 @@ module TestOperators
     end
 
     # All unary operators return NA when evaluating NA
-    for f in [+,-,*,/]
-        @assert isna(f(NA))
+    for f in [+, -]
+        @test isna(f(NA))
     end
 
     # All elementary functions return NA when evaluating NA
     for f in elementary_functions
-        @assert @eval isna(($f)(NA))
+        @test @eval isna(($f)(NA))
     end
 
     # All comparison operators return NA when comparing NA with NA
     # All comparison operators return NA when comparing scalars with NA
     # All comparison operators return NA when comparing NA with scalars
     for f in comparison_operators
-        @assert @eval isna(($f)(NA, NA))
-        @assert @eval isna(($f)(NA, 1))
-        @assert @eval isna(($f)(1, NA))
+        @test @eval isna(($f)(NA, NA))
+        @test @eval isna(($f)(NA, 1))
+        @test @eval isna(($f)(1, NA))
     end
 
     # All arithmetic operators7 return NA when operating on two NA's
     # All arithmetic operators return NA when operating on a scalar and an NA
     # All arithmetic operators return NA when operating on an NA and a scalar
     for f in arithmetic_operators
-        @assert @eval isna(($f)(NA, NA))
-        @assert @eval isna(($f)(1, NA))
-        @assert @eval isna(($f)(NA, 1))
+        @test @eval isna(($f)(NA, NA))
+        @test @eval isna(($f)(1, NA))
+        @test @eval isna(($f)(NA, 1))
     end
 
     # All bit operators return NA when operating on two NA's
     # All bit operators return NA when operating on a scalar and an NA
     # All bit operators return NA when operating on an NA and a scalar
     for f in bit_operators
-        @assert @eval isna(($f)(NA, NA))
-        @assert @eval isna(($f)(1, NA))
-        @assert @eval isna(($f)(NA, 1))
+        @test @eval isna(($f)(NA, NA))
+        @test @eval isna(($f)(1, NA))
+        @test @eval isna(($f)(NA, 1))
     end
 
     # Unary operators on DataVector's should be equivalent to elementwise
@@ -97,7 +91,7 @@ module TestOperators
     @test_da_pda dv begin
         for f in [+,-]
             for i in 1:length(dv)
-                @assert f(dv)[i] == f(dv[i])
+                @test f(dv)[i] == f(dv[i])
             end
         end
     end
@@ -105,7 +99,7 @@ module TestOperators
     @test_da_pda dv begin
         for f in [!]
             for i in 1:length(dv)
-                @assert f(dv)[i] == f(dv[i])
+                @test f(dv)[i] == f(dv[i])
             end
         end
     end
@@ -142,7 +136,7 @@ module TestOperators
     @test_da_pda dv begin
         for f in elementary_functions
             for i in 1:length(dv)
-                @assert @eval ($f).(dv)[$i] == ($f)(dv[$i])
+                @test @eval ($f).(dv)[$i] == ($f)(dv[$i])
             end
         end
     end
@@ -152,34 +146,34 @@ module TestOperators
     @test_da_pda dv begin
         for f in [+, *, Base.div, Base.mod, Base.fld, Base.rem]
             for i in 1:length(dv)
-                @assert isna(f(dv, NA)[i])
-                @assert isna(f(NA, dv)[i])
-                @assert f(dv, 1)[i] == f(dv[i], 1)
-                @assert f(1, dv)[i] == f(1, dv[i])
+                @test isna(f(dv, NA)[i])
+                @test isna(f(NA, dv)[i])
+                @test f(dv, 1)[i] == f(dv[i], 1)
+                @test f(1, dv)[i] == f(1, dv[i])
             end
         end
         for f in arithmetic_operators
             for i in 1:length(dv)
-                @assert @eval isna(($f).(dv, NA)[$i])
-                @assert @eval isna(($f).(NA, dv)[$i])
-                @assert @eval ($f).(dv, 1)[$i] == ($f)(dv[$i], 1)
-                @assert @eval ($f).(1, dv)[$i] == ($f)(1, dv[$i])
+                @test @eval isna(($f).(dv, NA)[$i])
+                @test @eval isna(($f).(NA, dv)[$i])
+                @test @eval ($f).(dv, 1)[$i] == ($f)(dv[$i], 1)
+                @test @eval ($f).(1, dv)[$i] == ($f)(1, dv[$i])
             end
         end
     end
 
     @test_da_pda dv begin
         for i in 1:length(dv)
-            @assert isna((dv / NA)[i])
-            @assert (dv / 1)[i] == dv[i] / 1
+            @test isna((dv / NA)[i])
+            @test (dv / 1)[i] == dv[i] / 1
         end
     end
 
     dv = @data([false, true, false, true, false])
     for f in bit_operators
         for i in 1:length(dv)
-            @assert @eval $(f).(dv, true)[$i] == ($f).(dv[$i], true)
-            @assert @eval $(f).(true, dv)[$i] == ($f).(true, dv[$i])
+            @test @eval $(f).(dv, true)[$i] == ($f).(dv[$i], true)
+            @test @eval $(f).(true, dv)[$i] == ($f).(true, dv[$i])
         end
     end
 
@@ -193,18 +187,18 @@ module TestOperators
     @test_da_pda dv begin
         for f in [:(+),:(-),:(*),:(^)]
             for i in 1:length(dv)
-                @assert @eval isna(($f).(v, dv)[$i]) && isna(dv[$i]) ||
+                @test @eval isna(($f).(v, dv)[$i]) && isna(dv[$i]) ||
                         ($f).(v, dv)[$i] == ($f)(v[$i], dv[$i])
-                @assert @eval isna(($f).(dv, v)[$i]) && isna(dv[$i]) ||
+                @test @eval isna(($f).(dv, v)[$i]) && isna(dv[$i]) ||
                         ($f).(dv, v)[$i] == ($f)(dv[$i], v[$i])
             end
         end
         for f in bit_operators
             for i in 1:length(bdv)
-                @assert @eval ($f).(bv, bdv)[$i]  == ($f).(bv[$i], bdv[$i])
-                @assert @eval ($f).(bdv, bv)[$i]  == ($f).(bdv[$i], bv[$i])
-                @assert @eval ($f).(bbv, bdv)[$i] == ($f).(bbv[$i], bdv[$i])
-                @assert @eval ($f).(bdv, bbv)[$i] == ($f).(bdv[$i], bbv[$i])
+                @test @eval ($f).(bv, bdv)[$i]  == ($f).(bv[$i], bdv[$i])
+                @test @eval ($f).(bdv, bv)[$i]  == ($f).(bdv[$i], bv[$i])
+                @test @eval ($f).(bbv, bdv)[$i] == ($f).(bbv[$i], bdv[$i])
+                @test @eval ($f).(bdv, bbv)[$i] == ($f).(bdv[$i], bbv[$i])
             end
         end
     end
@@ -217,25 +211,25 @@ module TestOperators
     @test_da_pda dv begin
         for f in [:(+),:(-),:(*),:(^)]
             for i in 1:length(dv)
-                @assert @eval isna(($f).(dv, dv)[$i]) && isna(dv[$i]) ||
+                @test @eval isna(($f).(dv, dv)[$i]) && isna(dv[$i]) ||
                         ($f).(dv, dv)[$i] == ($f)(dv[$i], dv[$i])
             end
         end
         for f in [+,-]
             for i in 1:length(dv)
-                @assert isna((f)(dv, dv)[i]) && isna(dv[i]) ||
+                @test isna((f)(dv, dv)[i]) && isna(dv[i]) ||
                         (f)(dv, dv)[i] == (f)(dv[i], dv[i])
             end
         end
         for f in bit_operators
             for i in 1:length(bv)
-                @assert @eval ($f).(bv, bv)[$i] == ($f).(bv[$i], bv[$i])
+                @test @eval ($f).(bv, bv)[$i] == ($f).(bv[$i], bv[$i])
             end
         end
         for i in 1:length(dvd)
-            @assert isna((dvd - dvd)[i]) && isna(dvd[i]) ||
+            @test isna((dvd - dvd)[i]) && isna(dvd[i]) ||
                     (dvd - dvd)[i] == dvd[i] - dvd[i]
-            @assert isna((dvd .- dvd)[i]) && isna(dvd[i]) ||
+            @test isna((dvd .- dvd)[i]) && isna(dvd[i]) ||
                     (dvd .- dvd)[i] == dvd[i] - dvd[i]
         end
     end
@@ -257,11 +251,11 @@ module TestOperators
                   convert(DataVector{Int}, dv),
                   convert(DataVector{Float32}, dv))
         for i in 1:length(curdv)
-            @assert isna((curdv./curdv)[i]) && isna(curdv[i]) ||
+            @test isna((curdv./curdv)[i]) && isna(curdv[i]) ||
                     isequal((curdv./curdv)[i], (curdv[i]./curdv[i]))
-            @assert isna((curdv./2)[i]) && isna(curdv[i]) ||
+            @test isna((curdv./2)[i]) && isna(curdv[i]) ||
                     isequal((curdv./2)[i], (curdv[i]./2))
-            @assert isna((curdv/2)[i]) && isna(curdv[i]) ||
+            @test isna((curdv/2)[i]) && isna(curdv[i]) ||
                     isequal((curdv/2)[i], (curdv[i]/2))
         end
     end
@@ -269,11 +263,11 @@ module TestOperators
     # Unary vector operators on DataVector's
     dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.unary_vector_operators)
-        @assert isequal(f(dv), f(dv.data))
+        @test isequal(f(dv), f(dv.data))
     end
     dv[1] = NA
     for f in map(eval, DataArrays.unary_vector_operators)
-        @assert isna(f(dv))
+        @test isna(f(dv))
     end
 
     # Pairwise vector operators on DataVector's
@@ -283,141 +277,141 @@ module TestOperators
     # Dates are an example of type for which operations return a different type from their inputs
     dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
     for f in pairwise_vector_operators
-        @assert isequal(f(dv), f(dv.data))
-        @assert isequal(f(dvd), f(dvd.data))
+        @test isequal(f(dv), f(dv.data))
+        @test isequal(f(dvd), f(dvd.data))
     end
     dv = @data([NA, 269, 835.0, 448, 772])
     dvd = @data([NA, Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
-        @assert isna(v[1])
-        @assert isequal(v[2:4], f(dv.data)[2:4])
+        @test isna(v[1])
+        @test isequal(v[2:4], f(dv.data)[2:4])
 
         d = f(dvd)
-        @assert isna(d[1])
-        @assert isequal(d[2:3], f(dvd.data)[2:3])
+        @test isna(d[1])
+        @test isequal(d[2:3], f(dvd.data)[2:3])
     end
     dv = @data([911, NA, 835.0, 448, 772])
     dvd = @data([Base.Date("2000-01-01"), NA, Base.Date("2010-01-01"), Base.Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
-        @assert isna(v[1])
-        @assert isna(v[2])
-        @assert isequal(v[3:4], f(dv.data)[3:4])
+        @test isna(v[1])
+        @test isna(v[2])
+        @test isequal(v[3:4], f(dv.data)[3:4])
 
         d = f(dvd)
-        @assert isna(d[1])
-        @assert isna(d[2])
-        @assert isequal(d[3:3], f(dvd.data)[3:3])
+        @test isna(d[1])
+        @test isna(d[2])
+        @test isequal(d[3:3], f(dvd.data)[3:3])
     end
     dv = @data([911, 269, 835.0, 448, NA])
     dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05"), NA])
     for f in pairwise_vector_operators
         v = f(dv)
-        @assert isna(v[4])
-        @assert isequal(v[1:3], f(dv.data)[1:3])
+        @test isna(v[4])
+        @test isequal(v[1:3], f(dv.data)[1:3])
 
         d = f(dvd)
-        @assert isna(d[3])
-        @assert isequal(d[1:2], f(dvd.data)[1:2])
+        @test isna(d[3])
+        @test isequal(d[1:2], f(dvd.data)[1:2])
     end
 
     # Cumulative vector operators on DataVector's
     dv = convert(DataArray, ones(5))
     for f in [Base.cumprod, Base.cumsum, t -> accumulate(min, t), t -> accumulate(max, t)]
         for i in 1:length(dv)
-            @assert f(dv)[i] == f(dv.data)[i]
+            @test f(dv)[i] == f(dv.data)[i]
         end
     end
     dv[4] = NA
     for f in [Base.cumprod, Base.cumsum]
         for i in 1:3
-            @assert f(dv)[i] == f(dv.data)[i]
+            @test f(dv)[i] == f(dv.data)[i]
         end
         for i in 4:5
-            @assert isna(f(dv)[i])
+            @test isna(f(dv)[i])
         end
     end
 
     # FFT's on DataVector's
     dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.ffts)
-        @assert f(dv) == f(dv.data)
+        @test f(dv) == f(dv.data)
     end
     dv[1] = NA
     for f in map(eval, DataArrays.ffts)
-        @assert isna(f(dv))
+        @test isna(f(dv))
     end
 
     # Binary vector operators on DataVector's
     dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.binary_vector_operators)
-        @assert f(dv, dv) == f(dv.data, dv.data) ||
+        @test f(dv, dv) == f(dv.data, dv.data) ||
                 (isnan(f(dv, dv)) && isnan(f(dv.data, dv.data)))
     end
     dv[1] = NA
     for f in map(eval, DataArrays.binary_vector_operators)
-        @assert isna(f(dv, dv))
+        @test isna(f(dv, dv))
     end
 
     # Boolean operators on DataVector's
-    @assert any(convert(DataArray, falses(5))) == false
-    @assert any(convert(DataArray, trues(5))) == true
-    @assert all(convert(DataArray, falses(5))) == false
-    @assert all(convert(DataArray, trues(5))) == true
-    @assert any(PooledDataArray(convert(DataArray, falses(5)))) == false
-    @assert any(PooledDataArray(convert(DataArray, trues(5)))) == true
-    @assert all(PooledDataArray(convert(DataArray, falses(5)))) == false
-    @assert all(PooledDataArray(convert(DataArray, trues(5)))) == true
+    @test any(convert(DataArray, falses(5))) == false
+    @test any(convert(DataArray, trues(5))) == true
+    @test all(convert(DataArray, falses(5))) == false
+    @test all(convert(DataArray, trues(5))) == true
+    @test any(PooledDataArray(convert(DataArray, falses(5)))) == false
+    @test any(PooledDataArray(convert(DataArray, trues(5)))) == true
+    @test all(PooledDataArray(convert(DataArray, falses(5)))) == false
+    @test all(PooledDataArray(convert(DataArray, trues(5)))) == true
 
     dv = convert(DataArray, falses(5))
     dv[3] = true
     @test_da_pda dv begin
-        @assert any(dv) == true
-        @assert all(dv) == false
+        @test any(dv) == true
+        @test all(dv) == false
     end
 
     dv = convert(DataArray, falses(5))
     dv[1] = NA
     @test_da_pda dv begin
-        @assert isna(any(dv))
-        @assert all(dv) == false
+        @test isna(any(dv))
+        @test all(dv) == false
     end
 
     dv = convert(DataArray, falses(5))
     dv[2] = NA
     dv[3] = true
     @test_da_pda dv begin
-        @assert any(dv) == true
-        @assert all(dv) == false
+        @test any(dv) == true
+        @test all(dv) == false
     end
 
     dv = convert(DataArray, falses(5))
     dv[2] = NA
     @test_da_pda dv begin
-        @assert isna(any(dv))
-        @assert all(dv) == false
+        @test isna(any(dv))
+        @test all(dv) == false
     end
 
     dv = convert(DataArray, falses(1))
     dv[1] = NA
     @test_da_pda dv begin
-        @assert isna(any(dv))
-        @assert isna(all(dv))
+        @test isna(any(dv))
+        @test isna(all(dv))
     end
 
     dv = convert(DataArray, trues(5))
     dv[1] = NA
     @test_da_pda dv begin
-        @assert any(dv) == true
-        @assert isna(all(dv))
+        @test any(dv) == true
+        @test isna(all(dv))
     end
 
     dv = convert(DataArray, trues(5))
     dv[2] = NA
     @test_da_pda dv begin
-        @assert any(dv) == true
-        @assert isna(all(dv))
+        @test any(dv) == true
+        @test isna(all(dv))
     end
 
     #
@@ -430,18 +424,18 @@ module TestOperators
     pdv = convert(PooledDataArray, @data([1, NA]))
     alt_pdv = convert(PooledDataArray, @data([2, NA]))
 
-    @assert isna(NA == NA)
-    @assert isna(NA != NA)
+    @test isna(NA == NA)
+    @test isna(NA != NA)
 
     function test_da_eq(v1::AbstractArray, v2::AbstractArray, out)
         for a in (v1, convert(DataArray, v1), convert(PooledDataArray, v1))
             for b in (v2, convert(DataArray, v2), convert(PooledDataArray, v2))
                 try
-                    @assert isequal(a == b, out)
-                    @assert isequal(b == a, out)
+                    @test isequal(a == b, out)
+                    @test isequal(b == a, out)
                     if size(a) == size(b)
-                        @assert isequal(all(a .== b), out)
-                        @assert isequal(all(b .== a), out)
+                        @test isequal(all(a .== b), out)
+                        @test isequal(all(b .== a), out)
                     end
                 catch e
                     println("a = $a")
@@ -465,30 +459,30 @@ module TestOperators
     # Comparing two arrays of unequal sizes returns false
     test_da_eq(dv, [1], false)
 
-    @assert isequal(dv, dv)
-    @assert isequal(pdv, pdv)
+    @test isequal(dv, dv)
+    @test isequal(pdv, pdv)
 
-    @assert !isequal(dv, alt_dv)
-    @assert !isequal(pdv, alt_pdv)
+    @test !isequal(dv, alt_dv)
+    @test !isequal(pdv, alt_pdv)
 
-    @assert isequal(@data([1, NA]) .== @data([1, NA]), @data([true, NA]))
-    @assert isequal(@pdata([1, NA]) .== @pdata([1, NA]), @data([true, NA]))
+    @test isequal(@data([1, NA]) .== @data([1, NA]), @data([true, NA]))
+    @test isequal(@pdata([1, NA]) .== @pdata([1, NA]), @data([true, NA]))
 
-    @assert all(isna(NA .== convert(DataArray, ones(5))))
-    @assert allna(isna(convert(DataArray, ones(5))) .== NA)
-    @assert all(isna(NA .== PooledDataArray(convert(DataArray, ones(5)))))
-    @assert allna(isna(convert(PooledDataArray, convert(DataArray, ones(5)))) .== NA)
+    @test all(isna(NA .== convert(DataArray, ones(5))))
+    @test allna(isna(convert(DataArray, ones(5))) .== NA)
+    @test all(isna(NA .== PooledDataArray(convert(DataArray, ones(5)))))
+    @test allna(isna(convert(PooledDataArray, convert(DataArray, ones(5)))) .== NA)
 
     # Run length encoding
     dv = convert(DataArray, ones(5))
     dv[3] = NA
 
     v, l = DataArrays.rle(dv)
-    @assert isequal(v, @data([1.0, NA, 1.0]))
-    @assert l == [2, 1, 2]
+    @test isequal(v, @data([1.0, NA, 1.0]))
+    @test l == [2, 1, 2]
 
     rdv = DataArrays.inverse_rle(v, l)
-    @assert isequal(dv, rdv)
+    @test isequal(dv, rdv)
 
     # Issue #90
     a = @data([false, true, false, true])

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -10,43 +10,43 @@ macro test_da_pda(da, code)
 end
 
 @testset "Operators" begin
-    const bit_operators = [:(&),:(|),:(⊻)]
+    const bit_operators = [&, |, ⊻]
 
-    const arithmetic_operators = [:(+),:(-),:(*),:(/), :(Base.div), :(Base.mod), :(Base.fld), :(Base.rem)]
+    const arithmetic_operators = [+, -, *, /, Base.div, Base.mod, Base.fld, Base.rem]
 
-    const comparison_operators = [:(==),:(!=),:(>),:(>=),:(<),:(<=)]
+    const comparison_operators = [==, !=, >, >=, <, <=]
 
-    const elementary_functions = [:(abs),
-                                  :(abs2),
-                                  :(sign),
-                                  :(acos),
-                                  :(acosh),
-                                  :(asin),
-                                  :(asinh),
-                                  :(atan),
-                                  :(atanh),
-                                  :(sin),
-                                  :(sinh),
-                                  :(conj),
-                                  :(cos),
-                                  :(cosh),
-                                  :(tan),
-                                  :(tanh),
-                                  :(ceil),
-                                  :(floor),
-                                  :(round),
-                                  :(trunc),
-                                  :(exp),
-                                  :(exp2),
-                                  :(expm1),
-                                  :(log),
-                                  :(log10),
-                                  :(log1p),
-                                  :(log2),
-                                  :(exponent),
-                                  :(sqrt),
-                                  :(gamma),
-                                  :(lgamma)]
+    const elementary_functions = [abs,
+                                  abs2,
+                                  sign,
+                                  acos,
+                                  acosh,
+                                  asin,
+                                  asinh,
+                                  atan,
+                                  atanh,
+                                  sin,
+                                  sinh,
+                                  conj,
+                                  cos,
+                                  cosh,
+                                  tan,
+                                  tanh,
+                                  ceil,
+                                  floor,
+                                  round,
+                                  trunc,
+                                  exp,
+                                  exp2,
+                                  expm1,
+                                  log,
+                                  log10,
+                                  log1p,
+                                  log2,
+                                  exponent,
+                                  sqrt,
+                                  gamma,
+                                  lgamma]
 
     # All unary operators return NA when evaluating NA
     for f in [+, -]
@@ -55,34 +55,34 @@ end
 
     # All elementary functions return NA when evaluating NA
     for f in elementary_functions
-        @test @eval isna(($f)(NA))
+        @test isna(f(NA))
     end
 
     # All comparison operators return NA when comparing NA with NA
     # All comparison operators return NA when comparing scalars with NA
     # All comparison operators return NA when comparing NA with scalars
     for f in comparison_operators
-        @test @eval isna(($f)(NA, NA))
-        @test @eval isna(($f)(NA, 1))
-        @test @eval isna(($f)(1, NA))
+        @test isna(f(NA, NA))
+        @test isna(f(NA, 1))
+        @test isna(f(1, NA))
     end
 
-    # All arithmetic operators7 return NA when operating on two NA's
+    # All arithmetic operators return NA when operating on two NA's
     # All arithmetic operators return NA when operating on a scalar and an NA
     # All arithmetic operators return NA when operating on an NA and a scalar
     for f in arithmetic_operators
-        @test @eval isna(($f)(NA, NA))
-        @test @eval isna(($f)(1, NA))
-        @test @eval isna(($f)(NA, 1))
+        @test isna(f(NA, NA))
+        @test isna(f(1, NA))
+        @test isna(f(NA, 1))
     end
 
     # All bit operators return NA when operating on two NA's
     # All bit operators return NA when operating on a scalar and an NA
     # All bit operators return NA when operating on an NA and a scalar
     for f in bit_operators
-        @test @eval isna(($f)(NA, NA))
-        @test @eval isna(($f)(1, NA))
-        @test @eval isna(($f)(NA, 1))
+        @test isna(f(NA, NA))
+        @test isna(f(1, NA))
+        @test isna(f(NA, 1))
     end
 
     # Unary operators on DataVector's should be equivalent to elementwise
@@ -136,7 +136,7 @@ end
     @test_da_pda dv begin
         for f in elementary_functions
             for i in 1:length(dv)
-                @test @eval ($f).(dv)[$i] == ($f)(dv[$i])
+                @test f.(dv)[i] == f(dv[i])
             end
         end
     end
@@ -154,10 +154,10 @@ end
         end
         for f in arithmetic_operators
             for i in 1:length(dv)
-                @test @eval isna(($f).(dv, NA)[$i])
-                @test @eval isna(($f).(NA, dv)[$i])
-                @test @eval ($f).(dv, 1)[$i] == ($f)(dv[$i], 1)
-                @test @eval ($f).(1, dv)[$i] == ($f)(1, dv[$i])
+                @test isna(f.(dv, NA)[i])
+                @test isna(f.(NA, dv)[i])
+                @test f.(dv, 1)[i] == f(dv[i], 1)
+                @test f.(1, dv)[i] == f(1, dv[i])
             end
         end
     end
@@ -172,8 +172,8 @@ end
     dv = @data([false, true, false, true, false])
     for f in bit_operators
         for i in 1:length(dv)
-            @test @eval $(f).(dv, true)[$i] == ($f).(dv[$i], true)
-            @test @eval $(f).(true, dv)[$i] == ($f).(true, dv[$i])
+            @test f.(dv, true)[i] == f.(dv[i], true)
+            @test f.(true, dv)[i] == f.(true, dv[i])
         end
     end
 
@@ -185,20 +185,18 @@ end
     bbv = BitArray([true, false, false, true, true])
     bdv = @data [false, true, false, false, true]
     @test_da_pda dv begin
-        for f in [:(+),:(-),:(*),:(^)]
+        for f in [+, -, *, ^]
             for i in 1:length(dv)
-                @test @eval isna(($f).(v, dv)[$i]) && isna(dv[$i]) ||
-                        ($f).(v, dv)[$i] == ($f)(v[$i], dv[$i])
-                @test @eval isna(($f).(dv, v)[$i]) && isna(dv[$i]) ||
-                        ($f).(dv, v)[$i] == ($f)(dv[$i], v[$i])
+                @test isna(f.(v, dv)[i]) && isna(dv[i]) || f.(v, dv)[i] == f(v[i], dv[i])
+                @test isna(f.(dv, v)[i]) && isna(dv[i]) || f.(dv, v)[i] == f(dv[i], v[i])
             end
         end
         for f in bit_operators
             for i in 1:length(bdv)
-                @test @eval ($f).(bv, bdv)[$i]  == ($f).(bv[$i], bdv[$i])
-                @test @eval ($f).(bdv, bv)[$i]  == ($f).(bdv[$i], bv[$i])
-                @test @eval ($f).(bbv, bdv)[$i] == ($f).(bbv[$i], bdv[$i])
-                @test @eval ($f).(bdv, bbv)[$i] == ($f).(bdv[$i], bbv[$i])
+                @test f.(bv, bdv)[i]  == f.(bv[i], bdv[i])
+                @test f.(bdv, bv)[i]  == f.(bdv[i], bv[i])
+                @test f.(bbv, bdv)[i] == f.(bbv[i], bdv[i])
+                @test f.(bdv, bbv)[i] == f.(bdv[i], bbv[i])
             end
         end
     end
@@ -209,28 +207,24 @@ end
     dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
     dv[1] = dvd[1] = NA
     @test_da_pda dv begin
-        for f in [:(+),:(-),:(*),:(^)]
+        for f in [+, -, *, ^]
             for i in 1:length(dv)
-                @test @eval isna(($f).(dv, dv)[$i]) && isna(dv[$i]) ||
-                        ($f).(dv, dv)[$i] == ($f)(dv[$i], dv[$i])
+                @test isna(f.(dv, dv)[i]) && isna(dv[i]) || f.(dv, dv)[i] == f(dv[i], dv[i])
             end
         end
         for f in [+,-]
             for i in 1:length(dv)
-                @test isna((f)(dv, dv)[i]) && isna(dv[i]) ||
-                        (f)(dv, dv)[i] == (f)(dv[i], dv[i])
+                @test isna((f)(dv, dv)[i]) && isna(dv[i]) || (f)(dv, dv)[i] == (f)(dv[i], dv[i])
             end
         end
         for f in bit_operators
             for i in 1:length(bv)
-                @test @eval ($f).(bv, bv)[$i] == ($f).(bv[$i], bv[$i])
+                @test f.(bv, bv)[i] == f.(bv[i], bv[i])
             end
         end
         for i in 1:length(dvd)
-            @test isna((dvd - dvd)[i]) && isna(dvd[i]) ||
-                    (dvd - dvd)[i] == dvd[i] - dvd[i]
-            @test isna((dvd .- dvd)[i]) && isna(dvd[i]) ||
-                    (dvd .- dvd)[i] == dvd[i] - dvd[i]
+            @test isna((dvd - dvd)[i]) && isna(dvd[i]) || (dvd - dvd)[i] == dvd[i] - dvd[i]
+            @test isna((dvd .- dvd)[i]) && isna(dvd[i]) || (dvd .- dvd)[i] == dvd[i] - dvd[i]
         end
     end
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -1,3 +1,14 @@
+macro test_da_pda(da, code)
+    esc(quote
+        let $da = copy($da)
+            $code
+        end
+        let $da = PooledDataArray($da)
+            $code
+        end
+    end)
+end
+
 @testset "Operators" begin
     const bit_operators = [:(&),:(|),:(⊻)]
 
@@ -36,17 +47,6 @@
                                   :(sqrt),
                                   :(gamma),
                                   :(lgamma)]
-
-    macro test_da_pda(da, code)
-        esc(quote
-            let $da = copy($da)
-                $code
-            end
-            let $da = PooledDataArray($da)
-                $code
-            end
-        end)
-    end
 
     # All unary operators return NA when evaluating NA
     for f in [+, -]

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -1,10 +1,7 @@
-module TestPadding
-    using Base.Test
-    using DataArrays
-
+@testset "Padding" begin
     dv = @data ones(3)
-    @assert isequal(dv, padNA(dv, 0, 0))
-    @assert length(padNA(dv, 2, 0)) == length(dv) + 2
-    @assert length(padNA(dv, 0, 2)) == length(dv) + 2
-    @assert length(padNA(dv, 2, 2)) == length(dv) + 4
+    @test isequal(dv, padNA(dv, 0, 0))
+    @test length(padNA(dv, 2, 0)) == length(dv) + 2
+    @test length(padNA(dv, 0, 2)) == length(dv) + 2
+    @test length(padNA(dv, 2, 2)) == length(dv) + 4
 end

--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -1,79 +1,75 @@
-module TestPDA
-    using Base.Test
-    using DataArrays
-    using Compat
-
+@testset "PDA" begin
     p = @pdata [9, 9, 8, NA, 1, 1]
     pcopy = copy(p)
-    @assert levels(p) == [1, 8, 9]
-    @assert levels(setlevels(p, ["a", "b", "c"])) == ["a", "b", "c"]
-    @assert dropna(setlevels(p, (@data ["a", "b", NA]))) == ["b", "a", "a"]
-    @assert dropna(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "a", "b", "a", "a"]
-    @assert levels(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "b"]
-    @assert levels(setlevels(p, Dict([(1, 111)]))) == [111, 8, 9]
-    @assert levels(setlevels(p, Dict([(1, 111), (8, NA)]))) == [111, 9]
-    @assert levels(PooledDataArray(p, [9, 8, 1])) == [9, 8, 1]
-    @assert levels(PooledDataArray(p, [9, 8])) == [9, 8]
-    @assert dropna(PooledDataArray(p, [9, 8])) == [9, 9, 8]
-    @assert levels(PooledDataArray(p, levels(p)[[3,2,1]])) == [9,8,1]
+    @test levels(p) == [1, 8, 9]
+    @test levels(setlevels(p, ["a", "b", "c"])) == ["a", "b", "c"]
+    @test dropna(setlevels(p, (@data ["a", "b", NA]))) == ["b", "a", "a"]
+    @test dropna(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "a", "b", "a", "a"]
+    @test levels(setlevels(p, (@data ["a", "b", "a"]))) == ["a", "b"]
+    @test levels(setlevels(p, Dict([(1, 111)]))) == [111, 8, 9]
+    @test levels(setlevels(p, Dict([(1, 111), (8, NA)]))) == [111, 9]
+    @test levels(PooledDataArray(p, [9, 8, 1])) == [9, 8, 1]
+    @test levels(PooledDataArray(p, [9, 8])) == [9, 8]
+    @test dropna(PooledDataArray(p, [9, 8])) == [9, 9, 8]
+    @test levels(PooledDataArray(p, levels(p)[[3,2,1]])) == [9,8,1]
     v = collect(1:6)
-    @assert isequal(p, reorder(p))
-    # @assert levels(reorder(p, v)) == [9,8,1]
-    @assert isequal(p, pcopy)
+    @test isequal(p, reorder(p))
+    # @test levels(reorder(p, v)) == [9,8,1]
+    @test isequal(p, pcopy)
 
-    @assert levels(setlevels!(copy(p), [10,80,90])) == [10, 80, 90]
-    @assert levels(setlevels!(copy(p), [1,8,1])) == [1, 8]
-    @assert levels(setlevels!(copy(p), (@data [1, 8, NA]))) == [1, 8]
-    @assert levels(setlevels!(copy(p), [1,8,9, 10])) == [1, 8, 9, 10]
-    @assert levels(setlevels!(copy(p), Dict([(1, 111)]))) == [111, 8, 9]
-    @assert levels(setlevels!(copy(p), Dict([(1, 111), (8, NA)]))) == [111, 9]
+    @test levels(setlevels!(copy(p), [10,80,90])) == [10, 80, 90]
+    @test levels(setlevels!(copy(p), [1,8,1])) == [1, 8]
+    @test levels(setlevels!(copy(p), (@data [1, 8, NA]))) == [1, 8]
+    @test levels(setlevels!(copy(p), [1,8,9, 10])) == [1, 8, 9, 10]
+    @test levels(setlevels!(copy(p), Dict([(1, 111)]))) == [111, 8, 9]
+    @test levels(setlevels!(copy(p), Dict([(1, 111), (8, NA)]))) == [111, 9]
     # issue #201
-    @assert levels(setlevels!(@pdata([1.0, 2.0]), [3,4])) == [3.0, 4.0]
+    @test levels(setlevels!(@pdata([1.0, 2.0]), [3,4])) == [3.0, 4.0]
 
     y = @pdata [1, NA, -2, 1, NA, 4, NA]
-    @assert isequal(unique(y), @pdata [1, NA, -2, 4])
-    @assert isequal(unique(reverse(y)), @data [NA, 4, 1, -2])
-    @assert isequal(unique(dropna(y)), @data [1, -2, 4])
-    @assert isequal(unique(reverse(dropna(y))), @data [4, 1, -2])
+    @test isequal(unique(y), @pdata [1, NA, -2, 4])
+    @test isequal(unique(reverse(y)), @data [NA, 4, 1, -2])
+    @test isequal(unique(dropna(y)), @data [1, -2, 4])
+    @test isequal(unique(reverse(dropna(y))), @data [4, 1, -2])
 
     z = @pdata ["frank", NA, "gertrude", "frank", NA, "herbert", NA]
-    @assert isequal(unique(z), @pdata ["frank", NA, "gertrude", "herbert"])
-    @assert isequal(unique(reverse(z)), @pdata [NA, "herbert", "frank", "gertrude"])
-    @assert isequal(unique(dropna(z)), @pdata ["frank", "gertrude", "herbert"])
-    @assert isequal(unique(reverse(dropna(z))), @pdata ["herbert", "frank", "gertrude"])
+    @test isequal(unique(z), @pdata ["frank", NA, "gertrude", "herbert"])
+    @test isequal(unique(reverse(z)), @pdata [NA, "herbert", "frank", "gertrude"])
+    @test isequal(unique(dropna(z)), @pdata ["frank", "gertrude", "herbert"])
+    @test isequal(unique(reverse(dropna(z))), @pdata ["herbert", "frank", "gertrude"])
 
     # check case where only NA occurs in final position
-    @assert isequal(unique(@pdata [1, 2, 1, NA]), @pdata [1, 2, NA])
+    @test isequal(unique(@pdata [1, 2, 1, NA]), @pdata [1, 2, NA])
 
     pp = PooledDataArray(Any[])
-    @assert length(pp) == 0
-    @assert length(levels(pp)) == 0
+    @test length(pp) == 0
+    @test length(levels(pp)) == 0
 
     # test construction with unordered types
     pim = @pdata [1 + im, 2 + im, 3 + im, 2 + im, 1 + im]
-    @assert levels(pim) == [1 + im, 2 + im, 3 + im]
+    @test levels(pim) == [1 + im, 2 + im, 3 + im]
 
     # Test explicitly setting refs type
     testarray = [1, 1, 2, 2, 0, 0, 3, 3]
     testdata = @data [1, 1, 2, 2, 0, 0, 3, 3]
     for t in Any[testarray, testdata]
         for R in [UInt8, UInt16, UInt32, UInt64]
-            @assert eltype(PooledDataArray(t, R).refs) == R
-            @assert eltype(PooledDataArray(t, [1,2,3], R).refs) == R
-            @assert eltype(PooledDataArray(t, [1,2,3], t .== 0, R).refs) == R
+            @test eltype(PooledDataArray(t, R).refs) == R
+            @test eltype(PooledDataArray(t, [1,2,3], R).refs) == R
+            @test eltype(PooledDataArray(t, [1,2,3], t .== 0, R).refs) == R
         end
     end
 
     pcopy = copy(p)
-    @assert levels(append!(pcopy, @pdata [4, NA, 6, 5])) == [1, 8, 9, 4, 5, 6]
+    @test levels(append!(pcopy, @pdata [4, NA, 6, 5])) == [1, 8, 9, 4, 5, 6]
 
     x = PooledDataArray([9, 9, 8])
     y = PooledDataArray([1, 9, 3, 2, 2])
-    @assert append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
+    @test append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
 
     x = PooledDataArray([9, 9, 8])
     y = [1, 9, 3, 2, 2]
-    @assert append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
+    @test append!(x, y) == [9, 9, 8, 1, 9, 3, 2, 2]
 
     # convert methods
     for from in (@pdata(ones(5, 5)), @data(ones(5, 5)), ones(5, 5))
@@ -96,14 +92,14 @@ module TestPDA
     end
 
     da = convert(DataArray, @pdata(ones(5, 5)))
-    @assert isequal(da, @data(ones(5, 5)))
-    @assert typeof(da) == DataArray{Float64,2}
+    @test isequal(da, @data(ones(5, 5)))
+    @test typeof(da) == DataArray{Float64,2}
     da = convert(DataArray{Float32}, @pdata(ones(5, 5)))
-    @assert isequal(da, @data(ones(Float32, 5, 5)))
-    @assert typeof(da) == DataArray{Float32,2}
+    @test isequal(da, @data(ones(Float32, 5, 5)))
+    @test typeof(da) == DataArray{Float32,2}
     da = convert(DataArray{Float32,2}, @pdata(ones(5, 5)))
-    @assert isequal(da, @data(ones(Float32, 5, 5)))
-    @assert typeof(da) == DataArray{Float32,2}
+    @test isequal(da, @data(ones(Float32, 5, 5)))
+    @test typeof(da) == DataArray{Float32,2}
 
     # permute
     pda = @pdata([NA, "A", "B", "C", "A", "B"])

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,3 +1,14 @@
+macro same_behavior(ex1, ex2)
+    quote
+        v = try
+            $ex2
+        catch e
+            e
+        end
+        isa(v, Exception) ? @test_throws(typeof(v), $ex1) : @test isapprox($ex1, v)
+    end
+end
+
 @testset "Reduce" begin
     srand(1337)
 
@@ -66,17 +77,6 @@
     end
 
     ## other reductions
-
-    macro same_behavior(ex1, ex2)
-        quote
-            v = try
-                $ex2
-            catch e
-                e
-            end
-            isa(v, Exception) ? @test_throws(typeof(v), $ex1) : @test isapprox($ex1, v)
-        end
-    end
 
     _varuc(x; kw...) = var(x; corrected=false, kw...)
     _varzm(x; kw...) = var(x; mean=0, kw...)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,152 +1,150 @@
-module TestReduce
-using DataArrays, Base.Test, StatsBase, Compat
+@testset "Reduce" begin
+    srand(1337)
 
-srand(1337)
+    ## extended test of sum
 
-## extended test of sum
+    for skipna in (true, false)
+        @test sum(@data(Int8[]); skipna=skipna) === Int32(0)
+        @test sum(@data(Int[]); skipna=skipna) === 0
+        @test sum(@data(Float64[]); skipna=skipna) === 0.0
 
-for skipna in (true, false)
-    @test sum(@data(Int8[]); skipna=skipna) === Int32(0)
-    @test sum(@data(Int[]); skipna=skipna) === 0
-    @test sum(@data(Float64[]); skipna=skipna) === 0.0
+        @test sum(@data([Int8(3)]); skipna=skipna) === Int32(3)
+        @test sum(@data([3]); skipna=skipna) === 3
+        @test sum(@data([3.0]); skipna=skipna) === 3.0
 
-    @test sum(@data([Int8(3)]); skipna=skipna) === Int32(3)
-    @test sum(@data([3]); skipna=skipna) === 3
-    @test sum(@data([3.0]); skipna=skipna) === 3.0
+        z = DataArray(reshape(1:16, (2,2,2,2)))
+        fz = convert(DataArray{Float64}, z)
+        bfz = convert(DataArray{BigFloat}, z)
+        @test sum(z) === 136
+        @test sum(fz) === 136.0
+        @test sum(bfz) == 136
+    end
+
+    @test sum(@data(Int[NA])) === NA
+    @test sum(@data(Int[NA]); skipna=true) === 0
+    @test sum(@data(Int[NA, NA])) === NA
+    @test sum(@data(Int[NA, NA]); skipna=true) === 0
+    @test sum(@data(Int[NA, NA, 1]); skipna=true) === 1
+    @test sum(@data(Int[NA, NA, 1, 2]); skipna=true) === 3
+    @test sum(@data(Int[NA, 1, NA, 1, 2]); skipna=true) === 4
 
     z = DataArray(reshape(1:16, (2,2,2,2)))
+    z[6] = NA
     fz = convert(DataArray{Float64}, z)
     bfz = convert(DataArray{BigFloat}, z)
-    @test sum(z) === 136
-    @test sum(fz) === 136.0
-    @test sum(bfz) == 136
-end
+    @test isna(sum(z))
+    @test isna(sum(fz))
+    @test isna(sum(bfz))
+    @test sum(z; skipna=true) === 130
+    @test sum(fz; skipna=true) === 130.0
+    @test sum(bfz; skipna=true) == 130
 
-@test sum(@data(Int[NA])) === NA
-@test sum(@data(Int[NA]); skipna=true) === 0
-@test sum(@data(Int[NA, NA])) === NA
-@test sum(@data(Int[NA, NA]); skipna=true) === 0
-@test sum(@data(Int[NA, NA, 1]); skipna=true) === 1
-@test sum(@data(Int[NA, NA, 1, 2]); skipna=true) === 3
-@test sum(@data(Int[NA, 1, NA, 1, 2]); skipna=true) === 4
-
-z = DataArray(reshape(1:16, (2,2,2,2)))
-z[6] = NA
-fz = convert(DataArray{Float64}, z)
-bfz = convert(DataArray{BigFloat}, z)
-@test isna(sum(z))
-@test isna(sum(fz))
-@test isna(sum(bfz))
-@test sum(z; skipna=true) === 130
-@test sum(fz; skipna=true) === 130.0
-@test sum(bfz; skipna=true) == 130
-
-bs = DataArrays.sum_pairwise_blocksize(identity)
-for n in [bs-64, bs-1, bs, bs+1, bs+2, 2*bs-2:2*bs+3..., 4*bs-2:4*bs+3...]
-    da = DataArray(randn(n))
-    s = sum(da.data)
-    @test sum(da) ≈ s
-    @test sum(da; skipna=true) ≈ s
-
-    da2 = copy(da)
-    da2[1:2:end] = NA
-    @test isna(sum(da2))
-    @test sum(da2; skipna=true) ≈ sum(dropna(da2))
-
-    da2 = convert(DataArray{BigFloat}, da2)
-    @test isna(sum(da2))
-    @test sum(da2; skipna=true) ≈ sum(dropna(da2))
-
-    da2 = copy(da)
-    da2[2:2:end] = NA
-    @test isna(sum(da2))
-    @test sum(da2; skipna=true) ≈ sum(dropna(da2))
-
-    da2 = convert(DataArray{BigFloat}, da2)
-    @test isna(sum(da2))
-    @test sum(da2; skipna=true) ≈ sum(dropna(da2))
-end
-
-## other reductions
-
-macro same_behavior(ex1, ex2)
-    quote
-        v = try
-            $ex2
-        catch e
-            e
-        end
-        isa(v, Exception) ? @test_throws(typeof(v), $ex1) : @test isapprox($ex1, v)
-    end
-end
-
-_varuc(x; kw...) = var(x; corrected=false, kw...)
-_varzm(x; kw...) = var(x; mean=0, kw...)
-_varzmuc(x; kw...) = var(x; corrected=false, mean=0, kw...)
-_var1m(x; kw...) = var(x; mean=1, kw...)
-_var1muc(x; kw...) = var(x; corrected=false, mean=1, kw...)
-_std1m(x; kw...) = stdm(x, 1; kw...)
-
-for fn in (prod, minimum, maximum, mean,
-           var, _varuc, _varzm, _varzmuc, _var1m, _var1muc,
-           std, _std1m, Base.sumabs, Base.sumabs2)
-    for n in [0, 1, 2, 62, 63, 64, 65, 66]
+    bs = DataArrays.sum_pairwise_blocksize(identity)
+    for n in [bs-64, bs-1, bs, bs+1, bs+2, 2*bs-2:2*bs+3..., 4*bs-2:4*bs+3...]
         da = DataArray(randn(n))
-        @same_behavior fn(da) fn(da.data)
-        @same_behavior fn(da; skipna=true) fn(da.data)
+        s = sum(da.data)
+        @test sum(da) ≈ s
+        @test sum(da; skipna=true) ≈ s
 
         da2 = copy(da)
         da2[1:2:end] = NA
-        n > 0 && @test isna(fn(da2))
-        @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+        @test isna(sum(da2))
+        @test sum(da2; skipna=true) ≈ sum(dropna(da2))
 
         da2 = convert(DataArray{BigFloat}, da2)
-        n > 0 && @test isna(fn(da2))
-        @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+        @test isna(sum(da2))
+        @test sum(da2; skipna=true) ≈ sum(dropna(da2))
 
         da2 = copy(da)
         da2[2:2:end] = NA
-        n > 1 && @test isna(fn(da2))
-        @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+        @test isna(sum(da2))
+        @test sum(da2; skipna=true) ≈ sum(dropna(da2))
 
         da2 = convert(DataArray{BigFloat}, da2)
-        n > 1 && @test isna(fn(da2))
-        @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+        @test isna(sum(da2))
+        @test sum(da2; skipna=true) ≈ sum(dropna(da2))
     end
-end
 
-## reduce and mapreduce drivers
+    ## other reductions
 
-for fn in (+, *, |, &)
-    da = convert(DataArray, bitrand(10))
+    macro same_behavior(ex1, ex2)
+        quote
+            v = try
+                $ex2
+            catch e
+                e
+            end
+            isa(v, Exception) ? @test_throws(typeof(v), $ex1) : @test isapprox($ex1, v)
+        end
+    end
 
-    s = mapreduce(identity, fn, da.data)
-    @test mapreduce(identity, fn, da) == s
-    @test mapreduce(identity, fn, da; skipna=true) == s
-    @test reduce(fn, da) == s
-    @test reduce(fn, da; skipna=true) == s
-end
+    _varuc(x; kw...) = var(x; corrected=false, kw...)
+    _varzm(x; kw...) = var(x; mean=0, kw...)
+    _varzmuc(x; kw...) = var(x; corrected=false, mean=0, kw...)
+    _var1m(x; kw...) = var(x; mean=1, kw...)
+    _var1muc(x; kw...) = var(x; corrected=false, mean=1, kw...)
+    _std1m(x; kw...) = stdm(x, 1; kw...)
 
-# make sure reductions of & and | are still calling Base
-@test isna(reduce(&, @data([true, NA])))
-@test !reduce(&, @data([false, NA]))
-@test reduce(|, @data([true, NA]))
-@test isna(reduce(|, @data([false, NA])))
+    for fn in (prod, minimum, maximum, mean,
+               var, _varuc, _varzm, _varzmuc, _var1m, _var1muc,
+               std, _std1m, Base.sumabs, Base.sumabs2)
+        for n in [0, 1, 2, 62, 63, 64, 65, 66]
+            da = DataArray(randn(n))
+            @same_behavior fn(da) fn(da.data)
+            @same_behavior fn(da; skipna=true) fn(da.data)
 
-# weighted mean
-da1 = DataArray(randn(128))
-da2 = DataArray(randn(128))
-@same_behavior mean(da1, weights(da2)) mean(da1.data, weights(da2.data))
-@same_behavior mean(da1, weights(da2.data)) mean(da1.data, weights(da2.data))
-@same_behavior mean(da1, weights(da2); skipna=true) mean(da1.data, weights(da2.data))
-@same_behavior mean(da1, weights(da2.data); skipna=true) mean(da1.data, weights(da2.data))
+            da2 = copy(da)
+            da2[1:2:end] = NA
+            n > 0 && @test isna(fn(da2))
+            @same_behavior fn(da2; skipna=true) fn(dropna(da2))
 
-da1[1:3:end] = NA
-@same_behavior mean(da1, weights(da2); skipna=true) mean(dropna(da1), weights(da2.data[(!).(da1.na)]))
-@same_behavior mean(da1, weights(da2.data); skipna=true) mean(dropna(da1), weights(da2.data[(!).(da1.na)]))
+            da2 = convert(DataArray{BigFloat}, da2)
+            n > 0 && @test isna(fn(da2))
+            @same_behavior fn(da2; skipna=true) fn(dropna(da2))
 
-da2[1:2:end] = NA
-keep = .!da1.na .& .!da2.na
-@test isna(mean(da1, weights(da2)))
-@same_behavior mean(da1, weights(da2); skipna=true) mean(da1.data[keep], weights(da2.data[keep]))
+            da2 = copy(da)
+            da2[2:2:end] = NA
+            n > 1 && @test isna(fn(da2))
+            @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+
+            da2 = convert(DataArray{BigFloat}, da2)
+            n > 1 && @test isna(fn(da2))
+            @same_behavior fn(da2; skipna=true) fn(dropna(da2))
+        end
+    end
+
+    ## reduce and mapreduce drivers
+
+    for fn in (+, *, |, &)
+        da = convert(DataArray, bitrand(10))
+
+        s = mapreduce(identity, fn, da.data)
+        @test mapreduce(identity, fn, da) == s
+        @test mapreduce(identity, fn, da; skipna=true) == s
+        @test reduce(fn, da) == s
+        @test reduce(fn, da; skipna=true) == s
+    end
+
+    # make sure reductions of & and | are still calling Base
+    @test isna(reduce(&, @data([true, NA])))
+    @test !reduce(&, @data([false, NA]))
+    @test reduce(|, @data([true, NA]))
+    @test isna(reduce(|, @data([false, NA])))
+
+    # weighted mean
+    da1 = DataArray(randn(128))
+    da2 = DataArray(randn(128))
+    @same_behavior mean(da1, weights(da2)) mean(da1.data, weights(da2.data))
+    @same_behavior mean(da1, weights(da2.data)) mean(da1.data, weights(da2.data))
+    @same_behavior mean(da1, weights(da2); skipna=true) mean(da1.data, weights(da2.data))
+    @same_behavior mean(da1, weights(da2.data); skipna=true) mean(da1.data, weights(da2.data))
+
+    da1[1:3:end] = NA
+    @same_behavior mean(da1, weights(da2); skipna=true) mean(dropna(da1), weights(da2.data[(!).(da1.na)]))
+    @same_behavior mean(da1, weights(da2.data); skipna=true) mean(dropna(da1), weights(da2.data[(!).(da1.na)]))
+
+    da2[1:2:end] = NA
+    keep = .!da1.na .& .!da2.na
+    @test isna(mean(da1, weights(da2)))
+    @same_behavior mean(da1, weights(da2); skipna=true) mean(da1.data[keep], weights(da2.data[keep]))
 end

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -1,180 +1,178 @@
-module TestReducedim
-using DataArrays, Base.Test, Compat
-
-# Test for fast unit stride BitArray functions
-function test_any()
-    bits = bitrand(64*5)
-    for i = 1:length(bits), j = i:length(bits)
-        v = false
-        for k = i:j
-            v |= bits[k]
-        end
-        Base.Test.@test DataArrays._any(bits, i, j) == v
-    end
-end
-test_any()
-
-function test_count()
-    bits = bitrand(64*5)
-    for i = 1:length(bits), j = i:length(bits)
-        v = 0
-        for k = i:j
-            v += bits[k]
-        end
-        Base.Test.@test DataArrays._count(bits, i, j) == v
-    end
-end
-test_count()
-
-# mapslices from Base, hacked to work for these cases
-function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
-    dims = intersect(region, 1:ndims(A))
-    if isempty(dims)
-        if skipna
-            naval = f(T[], 1)
-            A = copy(A)
-            A[isna(A)] = isempty(naval) ? NA : naval[1]
-        end
-        return A
-    end
-
-    if isempty(dims)
-        return map(f,A)
-    end
-
-    dimsA = collect(size(A))
-    ndimsA = ndims(A)
-    alldims = collect(1:ndimsA)
-
-    otherdims = setdiff(alldims, dims)
-
-    idx = Vector{Any}(ndimsA)
-    fill!(idx, 1)
-    Asliceshape = tuple(dimsA[dims]...)
-    itershape   = tuple(dimsA[otherdims]...)
-    for d in dims
-        idx[d] = 1:size(A,d)
-    end
-
-    r1 = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
-
-    # determine result size and allocate
-    Rsize = copy(dimsA)
-    # TODO: maybe support removing dimensions
-    if !isa(r1, AbstractArray) || ndims(r1) == 0
-        r2 = similar(A, T, 1)
-        r2[1] = r1
-        r1 = r2
-    end
-    Rsize[dims] = [size(r1)...; ones(Int,max(0,length(dims)-ndims(r1)))]
-    R = similar(r1, tuple(Rsize...))
-
-    ridx = Vector{Any}(ndims(R))
-    fill!(ridx, 1)
-    for d in dims
-        ridx[d] = 1:size(R,d)
-    end
-
-    R[ridx...] = r1
-
-    first = true
-
-    for idxs = CartesianRange(itershape)
-        if first
-            first = false
-        else
-            ia = [idxs.I...]
-            idx[otherdims] = ia
-            ridx[otherdims] = ia
-            try
-                R[ridx...] = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
-            catch e
-                if (isa(e, ErrorException) && e.msg == "Reducing over an empty array is not allowed.") || (isa(e, ArgumentError) && e.msg == "reducing over an empty collection is not allowed")
-
-                    R[ridx...] = NA
-                else
-                    println(typeof(e))
-                    rethrow(e)
-                end
+@testset "Reducedim" begin
+    # Test for fast unit stride BitArray functions
+    function test_any()
+        bits = bitrand(64*5)
+        for i = 1:length(bits), j = i:length(bits)
+            v = false
+            for k = i:j
+                v |= bits[k]
             end
+            Base.Test.@test DataArrays._any(bits, i, j) == v
         end
     end
+    test_any()
 
-    return R
-end
-
-macro test_da_approx_eq(da1, da2)
-    quote
-        v1 = $(esc(da1))
-        v2 = $(esc(da2))
-        na = isna(v1)
-        @test na == isna(v2)
-        defined = (!).(na)
-        if any(defined)
-            @test isapprox(v1[defined], v2[defined], nans = true)
+    function test_count()
+        bits = bitrand(64*5)
+        for i = 1:length(bits), j = i:length(bits)
+            v = 0
+            for k = i:j
+                v += bits[k]
+            end
+            Base.Test.@test DataArrays._count(bits, i, j) == v
         end
     end
-end
+    test_count()
 
-myvarzm(x; skipna::Bool=false) = var(x; mean=0, skipna=skipna)
-myvar1m(x; skipna::Bool=false) = var(x; mean=1, skipna=skipna)
+    # mapslices from Base, hacked to work for these cases
+    function safe_mapslices{T}(f::Function, A::AbstractArray{T}, region, skipna)
+        dims = intersect(region, 1:ndims(A))
+        if isempty(dims)
+            if skipna
+                naval = f(T[], 1)
+                A = copy(A)
+                A[isna(A)] = isempty(naval) ? NA : naval[1]
+            end
+            return A
+        end
 
-for Areduc in (DataArray(rand(3, 4, 5, 6)),
-               DataArray(rand(3, 4, 5, 6), rand(3, 4, 5, 6) .< 0.2))
-    for skipna = (false, true)
-        for region in Any[
-            1, 2, 3, 4, 5, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
-            (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)]
-            # println("region = $region, skipna = $skipna")
+        if isempty(dims)
+            return map(f,A)
+        end
 
-            outputs = Any[DataArray(fill(NaN, length.(Base.reduced_indices(indices(Areduc), region))))]
-            has_na = anyna(Areduc)
-            if has_na && !skipna
-                # Should throw an error reducing to non-DataArray
-                @test_throws NAException sum!(outputs[1].data, Areduc; skipna=skipna)
+        dimsA = collect(size(A))
+        ndimsA = ndims(A)
+        alldims = collect(1:ndimsA)
+
+        otherdims = setdiff(alldims, dims)
+
+        idx = Vector{Any}(ndimsA)
+        fill!(idx, 1)
+        Asliceshape = tuple(dimsA[dims]...)
+        itershape   = tuple(dimsA[otherdims]...)
+        for d in dims
+            idx[d] = 1:size(A,d)
+        end
+
+        r1 = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
+
+        # determine result size and allocate
+        Rsize = copy(dimsA)
+        # TODO: maybe support removing dimensions
+        if !isa(r1, AbstractArray) || ndims(r1) == 0
+            r2 = similar(A, T, 1)
+            r2[1] = r1
+            r1 = r2
+        end
+        Rsize[dims] = [size(r1)...; ones(Int,max(0,length(dims)-ndims(r1)))]
+        R = similar(r1, tuple(Rsize...))
+
+        ridx = Vector{Any}(ndims(R))
+        fill!(ridx, 1)
+        for d in dims
+            ridx[d] = 1:size(R,d)
+        end
+
+        R[ridx...] = r1
+
+        first = true
+
+        for idxs = CartesianRange(itershape)
+            if first
+                first = false
             else
-                # Should be able to reduce to non-DataArray
-                push!(outputs, outputs[1].data)
-            end
+                ia = [idxs.I...]
+                idx[otherdims] = ia
+                ridx[otherdims] = ia
+                try
+                    R[ridx...] = f(copy(reshape(A[idx...], Asliceshape)); skipna=skipna)
+                catch e
+                    if (isa(e, ErrorException) && e.msg == "Reducing over an empty array is not allowed.") || (isa(e, ArgumentError) && e.msg == "reducing over an empty collection is not allowed")
 
-            for r in outputs
-                @test_da_approx_eq sum!(r, Areduc; skipna=skipna) safe_mapslices(sum, Areduc, region, skipna)
-                @test_da_approx_eq prod!(r, Areduc; skipna=skipna) safe_mapslices(prod, Areduc, region, skipna)
-                if !has_na
-                    @test_da_approx_eq maximum!(r, Areduc; skipna=skipna) safe_mapslices(maximum, Areduc, region, skipna)
-                    @test_da_approx_eq minimum!(r, Areduc; skipna=skipna) safe_mapslices(minimum, Areduc, region, skipna)
+                        R[ridx...] = NA
+                    else
+                        println(typeof(e))
+                        rethrow(e)
+                    end
                 end
-                @test_da_approx_eq Base.sumabs!(r, Areduc; skipna=skipna) safe_mapslices(sum, abs(Areduc), region, skipna)
-                @test_da_approx_eq Base.sumabs2!(r, Areduc; skipna=skipna) safe_mapslices(sum, abs2(Areduc), region, skipna)
-                @test_da_approx_eq mean!(r, Areduc; skipna=skipna) safe_mapslices(mean, Areduc, region, skipna)
             end
+        end
 
-            @test_da_approx_eq sum(Areduc, region; skipna=skipna) safe_mapslices(sum, Areduc, region, skipna)
-            @test_da_approx_eq prod(Areduc, region; skipna=skipna) safe_mapslices(prod, Areduc, region, skipna)
-            @test_da_approx_eq maximum(Areduc, region; skipna=skipna) safe_mapslices(maximum, Areduc, region, skipna)
-            @test_da_approx_eq minimum(Areduc, region; skipna=skipna) safe_mapslices(minimum, Areduc, region, skipna)
-            @test_da_approx_eq Base.sumabs(Areduc, region; skipna=skipna) safe_mapslices(sum, abs(Areduc), region, skipna)
-            @test_da_approx_eq Base.sumabs2(Areduc, region; skipna=skipna) safe_mapslices(sum, abs2(Areduc), region, skipna)
-            @test_da_approx_eq mean(Areduc, region; skipna=skipna) safe_mapslices(mean, Areduc, region, skipna)
+        return R
+    end
 
-            if region != 5
-                @test_da_approx_eq var(Areduc, region; skipna=skipna) safe_mapslices(var, Areduc, region, skipna)
-                @test_da_approx_eq var(Areduc, region; mean=0, skipna=skipna) safe_mapslices(myvarzm, Areduc, region, skipna)
+    macro test_da_approx_eq(da1, da2)
+        quote
+            v1 = $(esc(da1))
+            v2 = $(esc(da2))
+            na = isna(v1)
+            @test na == isna(v2)
+            defined = (!).(na)
+            if any(defined)
+                @test isapprox(v1[defined], v2[defined], nans = true)
+            end
+        end
+    end
+
+    myvarzm(x; skipna::Bool=false) = var(x; mean=0, skipna=skipna)
+    myvar1m(x; skipna::Bool=false) = var(x; mean=1, skipna=skipna)
+
+    for Areduc in (DataArray(rand(3, 4, 5, 6)),
+                   DataArray(rand(3, 4, 5, 6), rand(3, 4, 5, 6) .< 0.2))
+        for skipna = (false, true)
+            for region in Any[
+                1, 2, 3, 4, 5, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
+                (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)]
+                # println("region = $region, skipna = $skipna")
+
+                outputs = Any[DataArray(fill(NaN, length.(Base.reduced_indices(indices(Areduc), region))))]
+                has_na = anyna(Areduc)
+                if has_na && !skipna
+                    # Should throw an error reducing to non-DataArray
+                    @test_throws NAException sum!(outputs[1].data, Areduc; skipna=skipna)
+                else
+                    # Should be able to reduce to non-DataArray
+                    push!(outputs, outputs[1].data)
+                end
+
                 for r in outputs
-                    @test_da_approx_eq var(Areduc, region; mean=fill!(r, 1), skipna=skipna) safe_mapslices(myvar1m, Areduc, region, skipna)
+                    @test_da_approx_eq sum!(r, Areduc; skipna=skipna) safe_mapslices(sum, Areduc, region, skipna)
+                    @test_da_approx_eq prod!(r, Areduc; skipna=skipna) safe_mapslices(prod, Areduc, region, skipna)
+                    if !has_na
+                        @test_da_approx_eq maximum!(r, Areduc; skipna=skipna) safe_mapslices(maximum, Areduc, region, skipna)
+                        @test_da_approx_eq minimum!(r, Areduc; skipna=skipna) safe_mapslices(minimum, Areduc, region, skipna)
+                    end
+                    @test_da_approx_eq Base.sumabs!(r, Areduc; skipna=skipna) safe_mapslices(sum, abs(Areduc), region, skipna)
+                    @test_da_approx_eq Base.sumabs2!(r, Areduc; skipna=skipna) safe_mapslices(sum, abs2(Areduc), region, skipna)
+                    @test_da_approx_eq mean!(r, Areduc; skipna=skipna) safe_mapslices(mean, Areduc, region, skipna)
+                end
+
+                @test_da_approx_eq sum(Areduc, region; skipna=skipna) safe_mapslices(sum, Areduc, region, skipna)
+                @test_da_approx_eq prod(Areduc, region; skipna=skipna) safe_mapslices(prod, Areduc, region, skipna)
+                @test_da_approx_eq maximum(Areduc, region; skipna=skipna) safe_mapslices(maximum, Areduc, region, skipna)
+                @test_da_approx_eq minimum(Areduc, region; skipna=skipna) safe_mapslices(minimum, Areduc, region, skipna)
+                @test_da_approx_eq Base.sumabs(Areduc, region; skipna=skipna) safe_mapslices(sum, abs(Areduc), region, skipna)
+                @test_da_approx_eq Base.sumabs2(Areduc, region; skipna=skipna) safe_mapslices(sum, abs2(Areduc), region, skipna)
+                @test_da_approx_eq mean(Areduc, region; skipna=skipna) safe_mapslices(mean, Areduc, region, skipna)
+
+                if region != 5
+                    @test_da_approx_eq var(Areduc, region; skipna=skipna) safe_mapslices(var, Areduc, region, skipna)
+                    @test_da_approx_eq var(Areduc, region; mean=0, skipna=skipna) safe_mapslices(myvarzm, Areduc, region, skipna)
+                    for r in outputs
+                        @test_da_approx_eq var(Areduc, region; mean=fill!(r, 1), skipna=skipna) safe_mapslices(myvar1m, Areduc, region, skipna)
+                    end
                 end
             end
         end
     end
-end
 
-# Test NA-skipping behavior for maximum
-a = @data([NA NA; 3 4])
-@test isequal(maximum(a, 1; skipna=true), [3 4])
-@test isequal(maximum!(zeros(1, 2), a; skipna=true), [3 4])
+    # Test NA-skipping behavior for maximum
+    a = @data([NA NA; 3 4])
+    @test isequal(maximum(a, 1; skipna=true), [3 4])
+    @test isequal(maximum!(zeros(1, 2), a; skipna=true), [3 4])
 
-# Maximum should give an NA in the output if all values along dimension are NA
-@test isequal(maximum(a, 2; skipna=true), @data([NA 4])')
-# Maximum should refuse to reduce to a non-DataArray
-@test_throws NAException maximum!(zeros(2, 1), a; skipna=true)
+    # Maximum should give an NA in the output if all values along dimension are NA
+    @test isequal(maximum(a, 2; skipna=true), @data([NA 4])')
+    # Maximum should refuse to reduce to a non-DataArray
+    @test_throws NAException maximum!(zeros(2, 1), a; skipna=true)
 end

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -1,3 +1,16 @@
+macro test_da_approx_eq(da1, da2)
+    quote
+        v1 = $(esc(da1))
+        v2 = $(esc(da2))
+        na = isna(v1)
+        @test na == isna(v2)
+        defined = (!).(na)
+        if any(defined)
+            @test isapprox(v1[defined], v2[defined], nans = true)
+        end
+    end
+end
+
 @testset "Reducedim" begin
     # Test for fast unit stride BitArray functions
     function test_any()
@@ -99,19 +112,6 @@
         end
 
         return R
-    end
-
-    macro test_da_approx_eq(da1, da2)
-        quote
-            v1 = $(esc(da1))
-            v2 = $(esc(da2))
-            na = isna(v1)
-            @test na == isna(v2)
-            defined = (!).(na)
-            if any(defined)
-                @test isapprox(v1[defined], v2[defined], nans = true)
-            end
-        end
     end
 
     myvarzm(x; skipna::Bool=false) = var(x; mean=0, skipna=skipna)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@
 
 using Base.Test
 using DataArrays
-using Compat
 
 my_tests = ["abstractarray.jl",
             "booleans.jl",
@@ -31,9 +30,6 @@ my_tests = ["abstractarray.jl",
             "newtests/datamatrix.jl",
             "newtests/datavector.jl"]
 
-println("Running tests:")
-
-for my_test in my_tests
-    @printf " * %s\n" my_test
-    include(my_test)
+for test in my_tests
+    include(test)
 end

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,29 +1,27 @@
-module TestSort
-using DataArrays, Base.Test, Compat
+@testset "Sort" begin
+    dv1 = @data([9, 1, 8, NA, 3, 3, 7, NA])
+    dv2 = 1.0 * dv1
+    dv3 = DataArray(collect(1:8))
+    pdv1 = convert(PooledDataArray, dv1)
 
-dv1 = @data([9, 1, 8, NA, 3, 3, 7, NA])
-dv2 = 1.0 * dv1
-dv3 = DataArray(collect(1:8))
-pdv1 = convert(PooledDataArray, dv1)
+    @test sortperm(dv1) == sortperm(dv2)
+    @test sortperm(dv1) == sortperm(pdv1)
+    @test isequal(sort(dv1), convert(DataArray, sort(dv1)))
+    @test isequal(sort(dv1), convert(DataArray, sort(pdv1)))
 
-@test sortperm(dv1) == sortperm(dv2)
-@test sortperm(dv1) == sortperm(pdv1)
-@test isequal(sort(dv1), convert(DataArray, sort(dv1)))
-@test isequal(sort(dv1), convert(DataArray, sort(pdv1)))
-
-for T in (Float64, BigFloat)
-    n = 1000
-    na = bitrand(n)
-    nna = sum(na)
-    a = Vector{T}(n)
-    ra = randn(n-nna)
-    a[.!na] = ra
-    for da in (DataArray(a, na), PooledDataArray(a, na), (pda = PooledDataArray(a, na); setlevels!(pda, shuffle!(pda.pool))))
-        @test isequal(sort(da), [DataArray(sort(dropna(da))); DataArray(T, nna)])
-        @test isequal(sort(da; lt=(x,y)->isless(x,y)), [DataArray(sort(dropna(da))); DataArray(T, nna)])
-        @test isequal(da[sortperm(da)], [DataArray(sort(dropna(da))); DataArray(T, nna)])
-        @test isequal(sort(da, rev=true), [DataArray(T, nna); DataArray(sort(dropna(da), rev=true))])
-        @test isequal(da[sortperm(da, rev=true)], [DataArray(T, nna); DataArray(sort(dropna(da), rev=true))])
+    for T in (Float64, BigFloat)
+        n = 1000
+        na = bitrand(n)
+        nna = sum(na)
+        a = Vector{T}(n)
+        ra = randn(n-nna)
+        a[.!na] = ra
+        for da in (DataArray(a, na), PooledDataArray(a, na), (pda = PooledDataArray(a, na); setlevels!(pda, shuffle!(pda.pool))))
+            @test isequal(sort(da), [DataArray(sort(dropna(da))); DataArray(T, nna)])
+            @test isequal(sort(da; lt=(x,y)->isless(x,y)), [DataArray(sort(dropna(da))); DataArray(T, nna)])
+            @test isequal(da[sortperm(da)], [DataArray(sort(dropna(da))); DataArray(T, nna)])
+            @test isequal(sort(da, rev=true), [DataArray(T, nna); DataArray(sort(dropna(da), rev=true))])
+            @test isequal(da[sortperm(da, rev=true)], [DataArray(T, nna); DataArray(sort(dropna(da), rev=true))])
+        end
     end
-end
 end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -1,8 +1,5 @@
-module TestStats
-    using Base.Test
-    using DataArrays
-
+@testset "Stats" begin
     autocor(DataArray([1, 2, 3, 4, 5]))
 
-    @assert isequal(xtabs([1, 2, 2, 2, 3]), Dict([(2, 3), (3, 1), (1, 1)]))
+    @test isequal(xtabs([1, 2, 2, 2, 3]), Dict([(2, 3), (3, 1), (1, 1)]))
 end


### PR DESCRIPTION
This PR restructures the tests to use `@testset` and `@test` rather than wrapping units of tests in modules and checking correctness with `@assert`.