### PR TITLE
Deprecate anyna(x) in favor of any(isna, x) (same for allna)

### DIFF
--- a/docs/src/da.md
+++ b/docs/src/da.md
@@ -20,8 +20,6 @@ DataVector
 DataMatrix
 @data
 isna
-allna
-anyna
 dropna
 padNA
 levels

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -17,8 +17,6 @@ module DataArrays
            AbstractDataArray,
            AbstractDataMatrix,
            AbstractDataVector,
-           allna,
-           anyna,
            array,
            autocor,
            compact,

--- a/src/abstractdataarray.jl
+++ b/src/abstractdataarray.jl
@@ -51,40 +51,6 @@ true
 isna{T}(a::AbstractArray{T}, i::Real) = NAtype <: T ? isa(a[i], NAtype) : false # -> Bool
 
 """
-    anyna(a::AbstractArray) -> Bool
-
-Determine whether any of the entries of `a` are `NA`.
-
-# Examples
-
-```jldoctest
-julia> anyna([1, 2, 3])
-false
-
-julia> anyna(@data [1, 2, NA])
-true
-```
-"""
-anyna(a::AbstractArray) = any(isna.(a)) # -> Bool
-
-"""
-    allna(a::AbstractArray) -> Bool
-
-Determine whether all elements of `a` are `NA`.
-
-# Examples
-
-```jldoctest
-julia> allna(@data [NA, NA])
-true
-
-julia> allna(@data [1, 2, NA])
-false
-```
-"""
-allna(a::AbstractArray) = all(isna.(a)) # -> Bool
-
-"""
     dropna(v::AbstractVector) -> AbstractVector
 
 Return a copy of `v` with all `NA` elements removed.

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -189,7 +189,7 @@ end
 
 function Base.convert{S, T, N}(::Type{Array{S, N}},
                                x::DataArray{T, N}) # -> Array{S, N}
-    if anyna(x)
+    if any(isna, x)
         err = "Cannot convert DataArray with NA's to desired type"
         throw(NAException(err))
     else
@@ -247,12 +247,12 @@ isna(da::DataArray, I::Real) = getindex(da.na, I)
 
 Base.broadcast(::typeof(isna), da::DataArray) = copy(da.na)
 
+Base.any(::typeof(isna), da::DataArray) = any(da.na) # -> Bool
+Base.all(::typeof(isna), da::DataArray) = all(da.na) # -> Bool
+
 @nsplat N function isna(da::DataArray, I::NTuple{N,Real}...)
     getindex(da.na, I...)
 end
-
-anyna(da::DataArray) = any(da.na) # -> Bool
-allna(da::DataArray) = all(da.na) # -> Bool
 
 function Base.isfinite(da::DataArray) # -> DataArray{Bool}
     n = length(da)
@@ -322,7 +322,7 @@ data(a::AbstractArray) = convert(DataArray, a)
 for f in (:(Base.float),)
     @eval begin
         function ($f)(da::DataArray) # -> DataArray
-            if anyna(da)
+            if any(isna, da)
                 err = "Cannot convert DataArray with NA's to desired type"
                 throw(NAException(err))
             else

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -7,3 +7,5 @@ function Base.isnan(da::DataArray)
 end
 
 @deprecate isna(x::AbstractArray) isna.(x)
+@deprecate anyna(x) any(isna, x)
+@deprecate allna(x) all(isna, x)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -87,7 +87,7 @@ elseif isdefined(Base, :checkindex)
 else
     Base.checkbounds(::Type{Bool}, sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz
     function Base.checkbounds{T<:Real}(::Type{Bool}, sz::Int, I::AbstractDataArray{T})
-        anyna(I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
+        any(isna, I) && throw(NAException("cannot index into an array with a DataArray containing NAs"))
         extr = daextract(I)
         b = true
         for i = 1:length(I)

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -231,14 +231,14 @@ end
 Base.broadcast(::typeof(isna), pda::PooledDataArray) = pda.refs .== 0
 isna(pda::PooledDataArray, i::Real) = pda.refs[i] == 0 # -> Bool
 
-function anyna(pda::PooledDataArray)
+function Base.any(::typeof(isna), pda::PooledDataArray)
     for ref in pda.refs
         ref == 0 && return true
     end
     return false
 end
 
-function allna(pda::PooledDataArray)
+function Base.all(::typeof(isna), pda::PooledDataArray)
     for ref in pda.refs
         ref == 0 || return false
     end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -180,7 +180,7 @@ function Base.mean(a::DataArray, w::WeightVec; skipna::Bool=false)
         v = a .* w.values
         sum(v; skipna=true) / sum(DataArray(w.values, v.na); skipna=true)
     else
-        anyna(a) ? NA : mean(a.data, w)
+        any(isna, a) ? NA : mean(a.data, w)
     end
 end
 
@@ -189,6 +189,6 @@ function Base.mean{W,V<:DataArray}(a::DataArray, w::WeightVec{W,V}; skipna::Bool
         v = a .* w.values
         sum(v; skipna=true) / sum(DataArray(w.values.data, v.na); skipna=true)
     else
-        anyna(a) || anyna(w.values) ? NA : wsum(a.data, w.values.data) / w.sum
+        any(isna, a) || any(isna, w.values) ? NA : wsum(a.data, w.values.data) / w.sum
     end
 end

--- a/test/nas.jl
+++ b/test/nas.jl
@@ -1,53 +1,53 @@
 @testset "NAs" begin
-    @testset "anyna(x)" begin
-        # anyna(a::AbstractArray)
-        @test anyna(Any[NA, 1])
-        @test !anyna([1, 2])
-        @test !anyna(repeat([1, 2], outer = [1, 2]))
-        @test !anyna(repeat([1, 2], outer = [1, 2, 2]))
+    @testset "any(isna, x)" begin
+        # any(isna, a::AbstractArray)
+        @test any(isna, Any[NA, 1])
+        @test !any(isna, [1, 2])
+        @test !any(isna, repeat([1, 2], outer = [1, 2]))
+        @test !any(isna, repeat([1, 2], outer = [1, 2, 2]))
 
-        # anyna(da::DataArray)
-        @test !anyna(DataArray([1, 2], falses(2)))
-        @test !anyna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        # any(isna, da::DataArray)
+        @test !any(isna, DataArray([1, 2], falses(2)))
+        @test !any(isna, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
         da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-        @test !anyna(da)
+        @test !any(isna, da)
         da[2] = NA
-        @test anyna(da)
+        @test any(isna, da)
 
-        # anyna(pda::PooledDataArray)
-        @test !anyna(PooledDataArray([1, 2], falses(2)))
-        @test !anyna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        # any(isna, pda::PooledDataArray)
+        @test !any(isna, PooledDataArray([1, 2], falses(2)))
+        @test !any(isna, PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
         pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
-        @test !anyna(pda)
+        @test !any(isna, pda)
         pda[2] = NA
-        @test anyna(pda)
+        @test any(isna, pda)
     end
 
-    @testset "allna(x)" begin
-        # allna(a::AbstractArray)
-        @test allna(Any[NA, NA])
-        @test !allna(Any[NA, 1])
-        @test !allna([1, 2])
-        @test !allna(repeat([1, 2], outer = [1, 2]))
-        @test !allna(repeat([1, 2], outer = [1, 2, 2]))
+    @testset "all(isna, x)" begin
+        # all(isna, a::AbstractArray)
+        @test all(isna, Any[NA, NA])
+        @test !all(isna, Any[NA, 1])
+        @test !all(isna, [1, 2])
+        @test !all(isna, repeat([1, 2], outer = [1, 2]))
+        @test !all(isna, repeat([1, 2], outer = [1, 2, 2]))
 
-        # allna(da::DataArray)
-        @test !allna(DataArray([1, 2], falses(2)))
-        @test !allna(DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        # all(isna, da::DataArray)
+        @test !all(isna, DataArray([1, 2], falses(2)))
+        @test !all(isna, DataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
         da = DataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
         da[1] = NA
-        @test !allna(da)
+        @test !all(isna, da)
         da[:] = NA
-        @test allna(da)
+        @test all(isna, da)
 
-        # allna(da::PooledDataArray)
-        @test !allna(PooledDataArray([1, 2], falses(2)))
-        @test !allna(PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
+        # all(isna, da::PooledDataArray)
+        @test !all(isna, PooledDataArray([1, 2], falses(2)))
+        @test !all(isna, PooledDataArray(repeat([1, 2], outer = [1, 2]), falses(2, 2)))
         pda = PooledDataArray(repeat([1, 2], outer = [1, 2, 2]), falses(2, 2, 2))
         pda[1] = NA
-        @test !allna(pda)
+        @test !all(isna, pda)
         pda[:] = NA
-        @test allna(pda)
+        @test all(isna, pda)
     end
 
     dv = DataArray(collect(1:6), fill(false, 6))

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -463,9 +463,9 @@ end
     @test isequal(@pdata([1, NA]) .== @pdata([1, NA]), @data([true, NA]))
 
     @test all(isna.(NA .== convert(DataArray, ones(5))))
-    @test allna(isna.(convert(DataArray, ones(5))) .== NA)
+    @test all(isna, isna.(convert(DataArray, ones(5))) .== NA)
     @test all(isna.(NA .== PooledDataArray(convert(DataArray, ones(5)))))
-    @test allna(isna.(convert(PooledDataArray, convert(DataArray, ones(5)))) .== NA)
+    @test all(isna, isna.(convert(PooledDataArray, convert(DataArray, ones(5)))) .== NA)
 
     # Run length encoding
     dv = convert(DataArray, ones(5))
@@ -483,6 +483,6 @@ end
     b = @data([false, false, true, true])
     a[:] = NA
     b[:] = NA
-    @test allna(a .& b)
-    @test allna(a .| b)
+    @test all(isna, a .& b)
+    @test all(isna, a .| b)
 end

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -126,7 +126,7 @@ end
                 # println("region = $region, skipna = $skipna")
 
                 outputs = Any[DataArray(fill(NaN, length.(Base.reduced_indices(indices(Areduc), region))))]
-                has_na = anyna(Areduc)
+                has_na = any(isna, Areduc)
                 if has_na && !skipna
                     # Should throw an error reducing to non-DataArray
                     @test_throws NAException sum!(outputs[1].data, Areduc; skipna=skipna)


### PR DESCRIPTION
Rather than defining new functions `anyna` and `allna`, this PR extends `Base.any` and `Base.all` with `isna` to achieve the same thing.