### PR TITLE
Fix isna(::DataArray) deprecation

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -250,8 +250,8 @@ Base.broadcast(::typeof(isna), da::DataArray) = copy(da.na)
 Base.any(::typeof(isna), da::DataArray) = any(da.na) # -> Bool
 Base.all(::typeof(isna), da::DataArray) = all(da.na) # -> Bool
 
-@nsplat N function isna(da::DataArray, I::NTuple{N,Real}...)
-    getindex(da.na, I...)
+@nsplat N function isna(da::DataArray, I::Real, Is::NTuple{N,Real}...)
+    getindex(da.na, I, Is...)
 end
 
 function Base.isfinite(da::DataArray) # -> DataArray{Bool}


### PR DESCRIPTION
The deprecation wasn't used as the varargs `isa(::DataArray, ::Real...)` method
unexpectedly took precedence. It shouldn't apply when there are zero indices,
so change its signature to reflect this.

Fixes multiple test failures in dependencies discussed at https://github.com/JuliaStats/DataArrays.jl/pull/243, https://github.com/JuliaLang/METADATA.jl/issues/9148 and https://github.com/dmbates/MixedModels.jl/issues/79.