### PR TITLE
Fix isna(::DataArray) deprecation (alternate take)

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -243,16 +243,13 @@ function Base.convert{T, N}(::Type{Array}, da::DataArray{T, N}, replacement::Any
 end
 
 dropna(dv::DataVector) = dv.data[.!dv.na] # -> Vector
-isna(da::DataArray, I::Real) = getindex(da.na, I)
 
 Base.broadcast(::typeof(isna), da::DataArray) = copy(da.na)
 
 Base.any(::typeof(isna), da::DataArray) = any(da.na) # -> Bool
 Base.all(::typeof(isna), da::DataArray) = all(da.na) # -> Bool
 
-@nsplat N function isna(da::DataArray, I::NTuple{N,Real}...)
-    getindex(da.na, I...)
-end
+isna(da::DataArray, I::Real, Is::Real...) = getindex(da.na, I, Is...)
 
 function Base.isfinite(da::DataArray) # -> DataArray{Bool}
     n = length(da)


### PR DESCRIPTION
The deprecation wasn't used as the varargs isa(::DataArray, ::Real...) method
unexpectedly took precedence. It shouldn't apply when there are zero indices,
so change its signature to reflect this.

Get rid of the @nsplat call which isn't needed here (and no longer used in
Julia Base).

-------------

This is a possibly cleaner alternative to https://github.com/JuliaStats/DataArrays.jl/pull/251. I don't understand why `@nsplat` was used here, but AFAICT we can remove it now since the function is so simple.