### PR TITLE
Add missing LineNumberNode to @swappable call (fixes #257)

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -138,7 +138,11 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                 if swappable
                     # For /, Array/Number is valid but not Number/Array
                     # All other operators should be swappable
-                    map!(x->Expr(:macrocall, Symbol("@swappable"), LineNumberNode(@__LINE__), x, scalarfunc), fns, fns)
+                    if VERSION < v"0.7.0-"
+                        map!(x->Expr(:macrocall, Symbol("@swappable"), x, scalarfunc), fns, fns)
+                    else
+                        map!(x->Expr(:macrocall, Symbol("@swappable"), LineNumberNode(@__LINE__), x, scalarfunc), fns, fns)
+                    end
                 end
                 Expr(:block, fns...)
             end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -138,7 +138,7 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                 if swappable
                     # For /, Array/Number is valid but not Number/Array
                     # All other operators should be swappable
-                    map!(x->Expr(:macrocall, Symbol("@swappable"), x, scalarfunc), fns, fns)
+                    map!(x->Expr(:macrocall, Symbol("@swappable"), LineNumberNode(@__LINE__), x, scalarfunc), fns, fns)
                 end
                 Expr(:block, fns...)
             end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -138,7 +138,7 @@ macro dataarray_binary_scalar(vectorfunc, scalarfunc, outtype, swappable)
                 if swappable
                     # For /, Array/Number is valid but not Number/Array
                     # All other operators should be swappable
-                    if VERSION < v"0.7.0-"
+                    if VERSION < v"0.7.0-DEV.328"
                         map!(x->Expr(:macrocall, Symbol("@swappable"), x, scalarfunc), fns, fns)
                     else
                         map!(x->Expr(:macrocall, Symbol("@swappable"), LineNumberNode(@__LINE__), x, scalarfunc), fns, fns)


### PR DESCRIPTION
There has been some change to Julia in the macrocall AST, adding the LineNumberNode.
Unless there is another change to Julia, some packages using `:macrocall` expression generation will break. 