### PR TITLE
Use === for booleans when == is overloaded

### DIFF
--- a/test/booleans.jl
+++ b/test/booleans.jl
@@ -1,23 +1,23 @@
 @testset "Booleans" begin
-    @test NA | true == true
+    @test NA | true === true
     @test isna(NA | false)
     @test isna(NA | NA)
-    @test true | NA == true
+    @test true | NA === true
     @test isna(false | NA)
 
     @test isna(NA & true)
-    @test NA & false == false
+    @test NA & false === false
     @test isna(NA & NA)
     @test isna(true & NA)
-    @test false & NA == false
+    @test false & NA === false
 
-    @test any((@data [1, 2, NA]) .== 1) == true
-    @test any((@data [NA, 1, 2]) .== 1) == true
+    @test any((@data [1, 2, NA]) .== 1) === true
+    @test any((@data [NA, 1, 2]) .== 1) === true
     @test isna(any((@data [1, 2, NA]) .== 3))
-    @test any((@data [1, 2, 3] ).== 4) == false
+    @test any((@data [1, 2, 3] ).== 4) === false
 
     @test isna(all((@data [1, 1, NA]) .== 1))
     @test isna(all((@data [NA, 1, 1]) .== 1))
-    @test all((@data [1, 1, 1]) .== 1) == true
-    @test all((@data [1, 2, 1]) .== 1) == false
+    @test all((@data [1, 1, 1]) .== 1) === true
+    @test all((@data [1, 2, 1]) .== 1) === false
 end


### PR DESCRIPTION
Test framework expects a pass/fail boolean from a test expression, but `==` can have NA value. Therefore it might be appropriate to use `===` in these cases. In fact, it might be smart to use `===` in all tests and packages when comparing an expression to a boolean value.
