### PR TITLE
Fix uninitialised values in unique for PooledDataArray

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -6,8 +6,6 @@ const unary_vector_operators = [:(Base.median),
 
 # TODO: dist, iqr
 
-const ffts = [:(Base.fft)]
-
 const binary_vector_operators = [:(Base.dot),
                                  :(Base.cor),
                                  :(Base.cov),
@@ -21,7 +19,6 @@ const rowwise_operators = [:rowminimums,
                            :rowmedians,
                            :rowstds,
                            :rowvars,
-                           :rowffts,
                            :rownorms]
 
 # Swap arguments to fname() anywhere in AST. Returns the number of
@@ -668,7 +665,7 @@ end
 Base.cumsum(dv::DataVector) = accumulate(+, dv)
 Base.cumprod(dv::DataVector)   = accumulate(*, dv)
 
-for f in [unary_vector_operators; ffts]
+for f in unary_vector_operators
     @eval ($f)(dv::DataVector) = any(dv.na) ? NA : ($f)(dv.data)
 end
 

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -334,7 +334,8 @@ function Base.unique{T}(pda::PooledDataArray{T})
     end
 
     if firstna > 0
-        res = DataArray(Vector{T}(nlevels + 1))
+        n = length(unique_values)
+        res = DataArray(Vector{T}(n + 1))
         i = 0
         for val in unique_values
             i += 1
@@ -345,8 +346,8 @@ function Base.unique{T}(pda::PooledDataArray{T})
             res.data[i] = val
         end
 
-        if firstna == nlevels + 1
-            res.na[nlevels + 1] = true
+        if firstna == n + 1
+            res.na[n + 1] = true
         end
 
         return res

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -327,16 +327,6 @@ end
         end
     end
 
-    # FFT's on DataVector's
-    dv = convert(DataArray, ones(5))
-    for f in map(eval, DataArrays.ffts)
-        @test f(dv) == f(dv.data)
-    end
-    dv[1] = NA
-    for f in map(eval, DataArrays.ffts)
-        @test isna(f(dv))
-    end
-
     # Binary vector operators on DataVector's
     dv = convert(DataArray, ones(5))
     for f in map(eval, DataArrays.binary_vector_operators)

--- a/test/pooleddataarray.jl
+++ b/test/pooleddataarray.jl
@@ -126,4 +126,18 @@
     r = vcat(ca1, ca2)
     @test r == vcat(a1, a2)
     @test isa(r, PooledDataArray{Int,DataArrays.DEFAULT_POOLED_REF_TYPE,4})
+
+    # Issue #265:
+    #   Ensure that any levels that have are not expressed in a
+    #   PooledDataArray are handled correctly and not left uninitialised when
+    #   using unique()
+    x = ["A", "B", "A"];
+    masks = [[1], [2], [3], [1, 3]]
+    for mask in masks
+        y = PooledDataArray(x)
+        y[mask] = NA
+        @test isequal(sort(unique(y)), sort(DataArray(unique(y))))
+    end
+    z = PooledDataArray([1, 2], [1, 2, 3])
+    @test sort(unique(z)) == DataArray([1, 2])
 end


### PR DESCRIPTION
Use the number of observed values (plus one for `NA`) to determine the
length of the result of `unique` on `PooledDataArrays`.

Fixes #265