### PR TITLE
Fix bitwise operator ambiguities, test for ambiguities, deprecate vectorized ops

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -58,3 +58,19 @@ function xtabs{T}(x::AbstractArray{T})
     end
     return d
 end
+
+# Implicitly vectorized bitwise operations
+
+import Base: &, |, xor
+
+for f in [:(&), :(|), :(xor)]
+    for T in [:(BitArray), :(Range{<:Integer}), :(AbstractArray{<:Integer}), :(Integer)]
+        @eval begin
+            @deprecate ($f)(a::DataArray{<:Integer}, b::$T) ($f).(a, b)
+            @deprecate ($f)(a::$T, b::DataArray{<:Integer}) ($f).(a, b)
+        end
+    end
+    @eval begin
+        @deprecate ($f)(a::DataArray{<:Integer}, b::DataArray{<:Integer}) ($f).(a, b)
+    end
+end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -372,24 +372,6 @@ for f in (:(&), :(|), :(Base.xor))
     end
 end
 
-# # DataArray with DataArray
-# (&)(a::DataArray{Bool}, b::DataArray{Bool}) =
-#     DataArray(a.data & b.data, (a.na & b.na) | (a.na & b.data) | (b.na & a.data))
-# (|)(a::DataArray{Bool}, b::DataArray{Bool}) =
-#     DataArray(a.data | b.data, (a.na & b.na) | (a.na & !b.data) | (b.na & !a.data))
-# ($)(a::DataArray{Bool}, b::DataArray{Bool}) =
-#     DataArray(a.data $ b.data, a.na | b.na)
-
-# DataArray with non-DataArray
-# Need explicit definition for BitArray to avoid ambiguity
-for t in (:(BitArray), :(Range{Bool}), :(Union{AbstractArray{Bool}, Bool}))
-    @eval begin
-        @swappable (&)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data & b), a.na & b)
-        @swappable (|)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data | b), a.na & !b)
-        @swappable ($)(a::DataArray{Bool}, b::$t) = DataArray(convert(Array{Bool}, a.data $ b), copy(a.na))
-    end
-end
-
 #
 # Comparison operators
 #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,3 +33,7 @@ my_tests = ["abstractarray.jl",
 for test in my_tests
     include(test)
 end
+
+@testset "Ambiguities" begin
+    @test_broken isempty(detect_ambiguities(DataArrays, Base, Core))
+end


### PR DESCRIPTION
This should fix the ambiguity error that occurs when attempting to `&`, `|`, or `xor` two `DataArray`s. This also deprecates that functionality in favor of dot `broadcast`. To top it off, I've added ambiguity detection to the tests.

cc @nalimilan, I think this is what you were running into in DataFramesMeta.