### PR TITLE
Minor 0.6 cleanup

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.0-pre
+julia 0.6
 Compat 0.8.6
 StatsBase 0.15.0
 Reexport

--- a/benchmark/operators.jl
+++ b/benchmark/operators.jl
@@ -1,5 +1,5 @@
 module DataArraysBenchmark
-using DataArrays, Benchmark, Compat
+using DataArrays, Benchmark
 
 # seed rng for more consistent timings
 srand(1776)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,7 +1,5 @@
-using DataArrays
 using Base: @get!, promote_eltype
 using Base.Broadcast: bitcache_chunks, bitcache_size, dumpbitcache
-using Compat: promote_eltype_op
 
 _broadcast_shape(x...) = Base.to_shape(Base.Broadcast.broadcast_indices(x...))
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -31,7 +31,7 @@ function percent_change{T}(v::Vector{T})
     return res
 end
 
-type xtab{T}
+mutable struct xtab{T}
     vals::Array{T}
     counts::Vector{Int}
 end

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -84,13 +84,13 @@ cut(x::AbstractVector, ngroups::Integer) = cut(x, quantile(x, collect(1 : ngroup
 function Base.repeat{T,N}(A::DataArray{T,N};
                           inner = ntuple(x->1, ndims(A)),
                           outer = ntuple(x->1, ndims(A)))
-    DataArray{T,N}(Compat.repeat(A.data; inner=inner, outer=outer),
-                   BitArray(Compat.repeat(A.na; inner=inner, outer=outer)))
+    DataArray{T,N}(repeat(A.data; inner=inner, outer=outer),
+                   BitArray(repeat(A.na; inner=inner, outer=outer)))
 end
 
 function Base.repeat{T,R,N}(A::PooledDataArray{T,R,N};
                             inner = ntuple(x->1, ndims(A)),
                             outer = ntuple(x->1, ndims(A)))
-    PooledDataArray(RefArray{R,N}(Compat.repeat(A.refs; inner=inner, outer=outer)),
+    PooledDataArray(RefArray{R,N}(repeat(A.refs; inner=inner, outer=outer)),
                     A.pool)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -496,7 +496,7 @@ end
 if isdefined(Base, :UniformScaling)
 
 function (+){TA,TJ}(A::DataArray{TA,2},J::UniformScaling{TJ})
-    n = Compat.LinAlg.checksquare(A)
+    n = LinAlg.checksquare(A)
     B = similar(A,promote_type(TA,TJ))
     copy!(B,A)
     @inbounds for i = 1:n
@@ -509,7 +509,7 @@ end
 (+){TA}(J::UniformScaling,A::DataArray{TA,2}) = A + J
 
 function (-){TA,TJ<:Number}(A::DataArray{TA,2},J::UniformScaling{TJ})
-    n = Compat.LinAlg.checksquare(A)
+    n = LinAlg.checksquare(A)
     B = similar(A,promote_type(TA,TJ))
     copy!(B,A)
     @inbounds for i = 1:n
@@ -520,7 +520,7 @@ function (-){TA,TJ<:Number}(A::DataArray{TA,2},J::UniformScaling{TJ})
     B
 end
 function (-){TA,TJ<:Number}(J::UniformScaling{TJ},A::DataArray{TA,2})
-    n = Compat.LinAlg.checksquare(A)
+    n = LinAlg.checksquare(A)
     B = -A
     @inbounds for i = 1:n
         if !B.na[i,i]

--- a/src/reducedim.jl
+++ b/src/reducedim.jl
@@ -336,7 +336,7 @@ Base.mean{T}(A::DataArray{T}, region; skipna::Bool=false) =
 
 ## var
 
-immutable MapReduceDim2ArgHelperFun{F,T}
+struct MapReduceDim2ArgHelperFun{F,T}
     f::F
     val::T
 end
@@ -478,7 +478,7 @@ end
     return R
 end
 
-immutable Abs2MinusFun end
+struct Abs2MinusFun end
 (::Abs2MinusFun)(x, m) = abs2(x - m)
 
 function Base.varm!(R::AbstractArray, A::DataArray, m::AbstractArray; corrected::Bool=true,

--- a/test/newtests/dataarray.jl
+++ b/test/newtests/dataarray.jl
@@ -2,7 +2,7 @@
 # TODO: Pull in existing tests into this file
 # TODO: Rename to TestDataArray
 module TestDataArrays
-    using DataArrays, Base.Test, Compat
+    using DataArrays, Base.Test
 
     # DataArray{T, N}(d::Array{T, N}, m::BitArray{N} = falses(size(d)))
     DataArray([1, 2], falses(2))


### PR DESCRIPTION
This change ~~removes the dependency on Compat (which was actually unused),~~ updates the type definition syntax to `struct`, and bumps the required Julia version from a 0.6 prerelease to 0.6 release.