### PR TITLE
Use the default Base implementation of map

### DIFF
--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -100,16 +100,6 @@ function Base.deleteat!(dv::DataVector, inds)
     dv
 end
 
-# TODO: should this be an AbstractDataVector, so it works with PDV's?
-function Base.map(f::Function, dv::DataVector)
-    n = length(dv)
-    res = DataArray(Any, n)
-    for i in 1:n
-        res[i] = f(dv[i])
-    end
-    return res
-end
-
 function Base.push!{T,R}(pdv::PooledDataVector{T,R}, v::NAtype)
     push!(pdv.refs, zero(R))
     return v

--- a/test/dataarray.jl
+++ b/test/dataarray.jl
@@ -97,4 +97,7 @@
         @test_throws BoundsError copy!(dest, 3, src, 1, 2)
         @test_throws BoundsError copy!(dest, 1, src, 2, 2)
     end
+
+    # Inferrability of map (#276)
+    @test eltype(map(x -> x > 1, @data [1, 2])) == Bool
 end


### PR DESCRIPTION
This ensures that we get the correct element type, among other things. Fixes #276.