### PR TITLE
Fix miscellaneous deprecations for latest Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
+Compat 0.41.0
 Missings 0.2.1
 StatsBase 0.15.0
 Reexport

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.41.0
+Compat 0.43.0
 Missings 0.2.1
 StatsBase 0.15.0
 Reexport

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -6,7 +6,7 @@ module DataArrays
     @reexport using StatsBase
     @reexport using Missings
     using SpecialFunctions
-    using Compat: AbstractRange, Nothing, uninitialized
+    using Compat: AbstractRange, Nothing, Cvoid, uninitialized, invpermute!
     using Compat.Printf, Compat.Dates
 
     const DEFAULT_POOLED_REF_TYPE = UInt32

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -15,6 +15,10 @@ module DataArrays
 
     import StatsBase: autocor, inverse_rle, rle
 
+    if VERSION >= v"0.7.0-DEV.3165"
+        import Base.replace!
+    end
+
     export @data,
            @pdata,
            AbstractDataArray,

--- a/src/DataArrays.jl
+++ b/src/DataArrays.jl
@@ -6,6 +6,8 @@ module DataArrays
     @reexport using StatsBase
     @reexport using Missings
     using SpecialFunctions
+    using Compat: AbstractRange, Nothing, uninitialized
+    using Compat.Printf, Compat.Dates
 
     const DEFAULT_POOLED_REF_TYPE = UInt32
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -58,165 +58,162 @@ end
 # TODO: Fall back on faster implementation for same-sized inputs when
 # it is safe to do so.
 
-if VERSION < v"0.7.0-DEV.2638"
+Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0::AbstractArray, As::AbstractArray...) where {F} =
+        broadcast!(f, B, A0, As...)
+Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0, As...) where {F} =
+        broadcast!(f, B, A0, As...)
 
-    Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0::AbstractArray, As::AbstractArray...) where {F} =
-            broadcast!(f, B, A0, As...)
-    Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0, As...) where {F} =
-            broadcast!(f, B, A0, As...)
+@generated function _broadcast!(f, B::Union{DataArray, PooledDataArray}, As...)
 
-    @generated function _broadcast!(f, B::Union{DataArray, PooledDataArray}, As...)
+    F  = :(f)
+    nd = ndims(B)
+    N  = length(As)
 
-        F  = :(f)
-        nd = ndims(B)
-        N  = length(As)
+    dataarrays = find(t -> t <: DataArray, As)
 
-        dataarrays = find(t -> t <: DataArray, As)
+    quote
+        @boundscheck Base.Broadcast.check_broadcast_indices(indices(B), As...)
+        # check_broadcast_shape(size(B), As...)
+        @nexprs $N i->(A_i = As[i])
 
-        quote
-            @boundscheck Base.Broadcast.check_broadcast_indices(indices(B), As...)
-            # check_broadcast_shape(size(B), As...)
-            @nexprs $N i->(A_i = As[i])
+        @assert ndims(B) == $nd
 
-            @assert ndims(B) == $nd
+        # Set up input DataArray/PooledDataArrays
+        $(Expr(:block, [
+            As[k] <: DataArray ? quote
+                $(Symbol("na_$(k)")) = $(Symbol("A_$(k)")).na.chunks
+                $(Symbol("data_$(k)")) = $(Symbol("A_$(k)")).data
+                $(Symbol("state_$(k)_0")) = $(Symbol("state_$(k)_$(nd)")) = 1
+                @nexprs $nd d->($(Symbol("skip_$(k)_d")) = size($(Symbol("data_$(k)")), d) == 1)
+            end : As[k] <: PooledDataArray ? quote
+                $(Symbol("refs_$(k)")) = $(Symbol("A_$(k)")).refs
+                $(Symbol("pool_$(k)")) = $(Symbol("A_$(k)")).pool
+            end : nothing
+        for k = 1:N]...))
 
-            # Set up input DataArray/PooledDataArrays
-            $(Expr(:block, [
+        # Set up output DataArray/PooledDataArray
+        $(if B <: DataArray
+            quote
+                Bdata = B.data
+                # Copy in case aliased
+                # TODO: check for aliasing?
+                Bna = falses(size(Bdata))
+                Bc = Bna.chunks
+                ind = 1
+            end
+        elseif B <: PooledDataArray
+            quote
+                Bpool = B.pool = similar(B.pool, 0)
+                Brefs = B.refs
+                Brefdict = Dict{eltype(Bpool),eltype(Brefs)}()
+            end
+        end)
+
+        @nloops($nd, i, $(B <: DataArray ? (:Bdata) : (:Brefs)),
+            # pre
+            d->($(Expr(:block, [
                 As[k] <: DataArray ? quote
-                    $(Symbol("na_$(k)")) = $(Symbol("A_$(k)")).na.chunks
-                    $(Symbol("data_$(k)")) = $(Symbol("A_$(k)")).data
-                    $(Symbol("state_$(k)_0")) = $(Symbol("state_$(k)_$(nd)")) = 1
-                    @nexprs $nd d->($(Symbol("skip_$(k)_d")) = size($(Symbol("data_$(k)")), d) == 1)
-                end : As[k] <: PooledDataArray ? quote
-                    $(Symbol("refs_$(k)")) = $(Symbol("A_$(k)")).refs
-                    $(Symbol("pool_$(k)")) = $(Symbol("A_$(k)")).pool
-                end : nothing
-            for k = 1:N]...))
-
-            # Set up output DataArray/PooledDataArray
-            $(if B <: DataArray
-                quote
-                    Bdata = B.data
-                    # Copy in case aliased
-                    # TODO: check for aliasing?
-                    Bna = falses(size(Bdata))
-                    Bc = Bna.chunks
-                    ind = 1
-                end
-            elseif B <: PooledDataArray
-                quote
-                    Bpool = B.pool = similar(B.pool, 0)
-                    Brefs = B.refs
-                    Brefdict = Dict{eltype(Bpool),eltype(Brefs)}()
-                end
-            end)
-
-            @nloops($nd, i, $(B <: DataArray ? (:Bdata) : (:Brefs)),
-                # pre
-                d->($(Expr(:block, [
-                    As[k] <: DataArray ? quote
-                        $(Symbol("state_$(k)_")){d-1} = $(Symbol("state_$(k)_d"));
-                        $(Symbol("j_$(k)_d")) = $(Symbol("skip_$(k)_d")) ? 1 : i_d
-                    end : (As[k] <: AbstractArray ? quote
-                        $(Symbol("j_$(k)_d")) = size($(Symbol("A_$(k)")), d) == 1 ? 1 : i_d
-                    end : quote
-                        $(Symbol("j_$(k)_d")) = 1
-                    end)
-                for k = 1:N]...))),
-
-                # post
-                d->($(Expr(:block, [quote
-                    $(Symbol("skip_$(k)_d")) || ($(Symbol("state_$(k)_d")) = $(Symbol("state_$(k)_0")))
-                end for k in dataarrays]...))),
-
-                # body
-                begin
-                    # Advance iterators for DataArray and determine missing status
-                    $(Expr(:block, [
-                        As[k] <: DataArray ? quote
-                            @inbounds $(Symbol("ismissing_$(k)")) = Base.unsafe_bitgetindex($(Symbol("na_$(k)")), $(Symbol("state_$(k)_0")))
-                        end : As[k] <: PooledDataArray ? quote
-                            @inbounds $(Symbol("r_$(k)")) = @nref $nd $(Symbol("refs_$(k)")) d->$(Symbol("j_$(k)_d"))
-                            $(Symbol("ismissing_$(k)")) = $(Symbol("r_$(k)")) == 0
-                        end : nothing
-                    for k = 1:N]...))
-
-                    # Extract values for other type
-                    $(Expr(:block, [
-                        As[k] <: AbstractArray  && !(As[k] <: AbstractDataArray) ? quote
-                            # ordinary AbstractArrays
-                            @inbounds $(Symbol("v_$(k)")) = @nref $nd $(Symbol("A_$(k)")) d->$(Symbol("j_$(k)_d"))
-                        end : quote
-                            # non AbstractArrays (e.g. Strings and Numbers)
-                            @inbounds $(Symbol("v_$(k)")) = $(Symbol("A_$(k)"))
-                        end
-                    for k = 1:N]...))
-
-                    # Compute and store return value
-                    $(gen_na_conds(F, nd, As, B))
-
-                    # Increment state
-                    $(Expr(:block, [:($(Symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
-                    $(if B <: DataArray
-                        :(ind += 1)
-                    end)
+                    $(Symbol("state_$(k)_")){d-1} = $(Symbol("state_$(k)_d"));
+                    $(Symbol("j_$(k)_d")) = $(Symbol("skip_$(k)_d")) ? 1 : i_d
+                end : (As[k] <: AbstractArray ? quote
+                    $(Symbol("j_$(k)_d")) = size($(Symbol("A_$(k)")), d) == 1 ? 1 : i_d
+                end : quote
+                    $(Symbol("j_$(k)_d")) = 1
                 end)
+            for k = 1:N]...))),
 
-            $(if B <: DataArray
-                :(B.na = Bna)
+            # post
+            d->($(Expr(:block, [quote
+                $(Symbol("skip_$(k)_d")) || ($(Symbol("state_$(k)_d")) = $(Symbol("state_$(k)_0")))
+            end for k in dataarrays]...))),
+
+            # body
+            begin
+                # Advance iterators for DataArray and determine missing status
+                $(Expr(:block, [
+                    As[k] <: DataArray ? quote
+                        @inbounds $(Symbol("ismissing_$(k)")) = Base.unsafe_bitgetindex($(Symbol("na_$(k)")), $(Symbol("state_$(k)_0")))
+                    end : As[k] <: PooledDataArray ? quote
+                        @inbounds $(Symbol("r_$(k)")) = @nref $nd $(Symbol("refs_$(k)")) d->$(Symbol("j_$(k)_d"))
+                        $(Symbol("ismissing_$(k)")) = $(Symbol("r_$(k)")) == 0
+                    end : nothing
+                for k = 1:N]...))
+
+                # Extract values for other type
+                $(Expr(:block, [
+                    As[k] <: AbstractArray  && !(As[k] <: AbstractDataArray) ? quote
+                        # ordinary AbstractArrays
+                        @inbounds $(Symbol("v_$(k)")) = @nref $nd $(Symbol("A_$(k)")) d->$(Symbol("j_$(k)_d"))
+                    end : quote
+                        # non AbstractArrays (e.g. Strings and Numbers)
+                        @inbounds $(Symbol("v_$(k)")) = $(Symbol("A_$(k)"))
+                    end
+                for k = 1:N]...))
+
+                # Compute and store return value
+                $(gen_na_conds(F, nd, As, B))
+
+                # Increment state
+                $(Expr(:block, [:($(Symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
+                $(if B <: DataArray
+                    :(ind += 1)
+                end)
             end)
 
-            return B
-        end
+        $(if B <: DataArray
+            :(B.na = Bna)
+        end)
+
+        return B
     end
-    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, ::Type{T}, As...) where T =
-        _broadcast!((t...) -> f(T, t...), B, As...)
-    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0::Number, As::Number...) =
-        _broadcast!(f, B, A0, As...)
-    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0, As...) =
-        _broadcast!(f, B, A0, As...)
-
-    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{DataArray})             = DataArray
-    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{PooledDataArray}) = PooledDataArray
-    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{Array})                 = DataArray
-    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{Array})           = PooledDataArray
-    Base.Broadcast.promote_containertype(::Type{Array}, ::Type{DataArray})                 = DataArray
-    Base.Broadcast.promote_containertype(::Type{Array}, ::Type{PooledDataArray})           = PooledDataArray
-    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{PooledDataArray})       = DataArray
-    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{DataArray})       = DataArray
-    Base.Broadcast.promote_containertype(::Type{DataArray}, ct)                            = DataArray
-    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ct)                      = PooledDataArray
-    Base.Broadcast.promote_containertype(ct, ::Type{DataArray})                            = DataArray
-    Base.Broadcast.promote_containertype(ct, ::Type{PooledDataArray})                      = PooledDataArray
-    Base.Broadcast._containertype(::Type{T}) where T<:DataArray           = DataArray
-    Base.Broadcast._containertype(::Type{T}) where T<:PooledDataArray     = PooledDataArray
-    Base.Broadcast.broadcast_indices(::Type{T}, A) where T<:AbstractDataArray = indices(A)
-
-    @inline function broadcast_t(f, ::Type{T}, shape, A, Bs...) where {T}
-        dest = Base.Broadcast.containertype(A, Bs...)(Missings.T(T), Base.index_lengths(shape...))
-        return broadcast!(f, dest, A, Bs...)
-    end
-
-    # This is mainly to handle ismissing.(x) since ismissing is probably the only
-    # function that can guarantee that missings will never propagate
-    @inline function broadcast_t(f, ::Type{Bool}, shape, A, Bs...)
-        dest = similar(BitArray, shape)
-        return broadcast!(f, dest, A, Bs...)
-    end
-
-    # This one is almost identical to the version in Base and can hopefully be
-    # removed at some point. The main issue in Base is that it tests for
-    # isleaftype(T) which is false for Union{T,Missing}. If the test in Base
-    # can be modified to cover simple unions of leaftypes then this method
-    # can probably be deleted and the two _t methods adjusted to match the Base
-    # invokation from Base.Broadcast.broadcast_c
-    @inline function Base.Broadcast.broadcast_c(f, ::Type{S}, A, Bs...) where {S<:AbstractDataArray}
-        T     = Base.Broadcast._broadcast_eltype(f, A, Bs...)
-        shape = Base.Broadcast.broadcast_indices(A, Bs...)
-        return broadcast_t(f, T, shape, A, Bs...)
-    end
-
-    # This one is much faster than normal broadcasting but the method won't get called
-    # in fusing operations like (!).(ismissing.(x))
-    Base.broadcast(::typeof(ismissing), da::DataArray) = copy(da.na)
 end
+Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, ::Type{T}, As...) where T =
+    _broadcast!((t...) -> f(T, t...), B, As...)
+Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0::Number, As::Number...) =
+    _broadcast!(f, B, A0, As...)
+Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0, As...) =
+    _broadcast!(f, B, A0, As...)
+
+Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{DataArray})             = DataArray
+Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{PooledDataArray}) = PooledDataArray
+Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{Array})                 = DataArray
+Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{Array})           = PooledDataArray
+Base.Broadcast.promote_containertype(::Type{Array}, ::Type{DataArray})                 = DataArray
+Base.Broadcast.promote_containertype(::Type{Array}, ::Type{PooledDataArray})           = PooledDataArray
+Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{PooledDataArray})       = DataArray
+Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{DataArray})       = DataArray
+Base.Broadcast.promote_containertype(::Type{DataArray}, ct)                            = DataArray
+Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ct)                      = PooledDataArray
+Base.Broadcast.promote_containertype(ct, ::Type{DataArray})                            = DataArray
+Base.Broadcast.promote_containertype(ct, ::Type{PooledDataArray})                      = PooledDataArray
+Base.Broadcast._containertype(::Type{T}) where T<:DataArray           = DataArray
+Base.Broadcast._containertype(::Type{T}) where T<:PooledDataArray     = PooledDataArray
+Base.Broadcast.broadcast_indices(::Type{T}, A) where T<:AbstractDataArray = indices(A)
+
+@inline function broadcast_t(f, ::Type{T}, shape, A, Bs...) where {T}
+    dest = Base.Broadcast.containertype(A, Bs...)(Missings.T(T), Base.index_lengths(shape...))
+    return broadcast!(f, dest, A, Bs...)
+end
+
+# This is mainly to handle ismissing.(x) since ismissing is probably the only
+# function that can guarantee that missings will never propagate
+@inline function broadcast_t(f, ::Type{Bool}, shape, A, Bs...)
+    dest = similar(BitArray, shape)
+    return broadcast!(f, dest, A, Bs...)
+end
+
+# This one is almost identical to the version in Base and can hopefully be
+# removed at some point. The main issue in Base is that it tests for
+# isleaftype(T) which is false for Union{T,Missing}. If the test in Base
+# can be modified to cover simple unions of leaftypes then this method
+# can probably be deleted and the two _t methods adjusted to match the Base
+# invokation from Base.Broadcast.broadcast_c
+@inline function Base.Broadcast.broadcast_c(f, ::Type{S}, A, Bs...) where {S<:AbstractDataArray}
+    T     = Base.Broadcast._broadcast_eltype(f, A, Bs...)
+    shape = Base.Broadcast.broadcast_indices(A, Bs...)
+    return broadcast_t(f, T, shape, A, Bs...)
+end
+
+# This one is much faster than normal broadcasting but the method won't get called
+# in fusing operations like (!).(ismissing.(x))
+Base.broadcast(::typeof(ismissing), da::DataArray) = copy(da.na)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -57,162 +57,166 @@ end
 #
 # TODO: Fall back on faster implementation for same-sized inputs when
 # it is safe to do so.
-Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0::AbstractArray, As::AbstractArray...) where {F} =
-        broadcast!(f, B, A0, As...)
-Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0, As...) where {F} =
-        broadcast!(f, B, A0, As...)
 
-@generated function _broadcast!(f, B::Union{DataArray, PooledDataArray}, As...)
+if VERSION < v"0.7.0-DEV.2638"
 
-    F  = :(f)
-    nd = ndims(B)
-    N  = length(As)
+    Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0::AbstractArray, As::AbstractArray...) where {F} =
+            broadcast!(f, B, A0, As...)
+    Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0, As...) where {F} =
+            broadcast!(f, B, A0, As...)
 
-    dataarrays = find(t -> t <: DataArray, As)
+    @generated function _broadcast!(f, B::Union{DataArray, PooledDataArray}, As...)
 
-    quote
-        @boundscheck Base.Broadcast.check_broadcast_indices(indices(B), As...)
-        # check_broadcast_shape(size(B), As...)
-        @nexprs $N i->(A_i = As[i])
+        F  = :(f)
+        nd = ndims(B)
+        N  = length(As)
 
-        @assert ndims(B) == $nd
+        dataarrays = find(t -> t <: DataArray, As)
 
-        # Set up input DataArray/PooledDataArrays
-        $(Expr(:block, [
-            As[k] <: DataArray ? quote
-                $(Symbol("na_$(k)")) = $(Symbol("A_$(k)")).na.chunks
-                $(Symbol("data_$(k)")) = $(Symbol("A_$(k)")).data
-                $(Symbol("state_$(k)_0")) = $(Symbol("state_$(k)_$(nd)")) = 1
-                @nexprs $nd d->($(Symbol("skip_$(k)_d")) = size($(Symbol("data_$(k)")), d) == 1)
-            end : As[k] <: PooledDataArray ? quote
-                $(Symbol("refs_$(k)")) = $(Symbol("A_$(k)")).refs
-                $(Symbol("pool_$(k)")) = $(Symbol("A_$(k)")).pool
-            end : nothing
-        for k = 1:N]...))
+        quote
+            @boundscheck Base.Broadcast.check_broadcast_indices(indices(B), As...)
+            # check_broadcast_shape(size(B), As...)
+            @nexprs $N i->(A_i = As[i])
 
-        # Set up output DataArray/PooledDataArray
-        $(if B <: DataArray
-            quote
-                Bdata = B.data
-                # Copy in case aliased
-                # TODO: check for aliasing?
-                Bna = falses(size(Bdata))
-                Bc = Bna.chunks
-                ind = 1
-            end
-        elseif B <: PooledDataArray
-            quote
-                Bpool = B.pool = similar(B.pool, 0)
-                Brefs = B.refs
-                Brefdict = Dict{eltype(Bpool),eltype(Brefs)}()
-            end
-        end)
+            @assert ndims(B) == $nd
 
-        @nloops($nd, i, $(B <: DataArray ? (:Bdata) : (:Brefs)),
-            # pre
-            d->($(Expr(:block, [
+            # Set up input DataArray/PooledDataArrays
+            $(Expr(:block, [
                 As[k] <: DataArray ? quote
-                    $(Symbol("state_$(k)_")){d-1} = $(Symbol("state_$(k)_d"));
-                    $(Symbol("j_$(k)_d")) = $(Symbol("skip_$(k)_d")) ? 1 : i_d
-                end : (As[k] <: AbstractArray ? quote
-                    $(Symbol("j_$(k)_d")) = size($(Symbol("A_$(k)")), d) == 1 ? 1 : i_d
-                end : quote
-                    $(Symbol("j_$(k)_d")) = 1
-                end)
-            for k = 1:N]...))),
+                    $(Symbol("na_$(k)")) = $(Symbol("A_$(k)")).na.chunks
+                    $(Symbol("data_$(k)")) = $(Symbol("A_$(k)")).data
+                    $(Symbol("state_$(k)_0")) = $(Symbol("state_$(k)_$(nd)")) = 1
+                    @nexprs $nd d->($(Symbol("skip_$(k)_d")) = size($(Symbol("data_$(k)")), d) == 1)
+                end : As[k] <: PooledDataArray ? quote
+                    $(Symbol("refs_$(k)")) = $(Symbol("A_$(k)")).refs
+                    $(Symbol("pool_$(k)")) = $(Symbol("A_$(k)")).pool
+                end : nothing
+            for k = 1:N]...))
 
-            # post
-            d->($(Expr(:block, [quote
-                $(Symbol("skip_$(k)_d")) || ($(Symbol("state_$(k)_d")) = $(Symbol("state_$(k)_0")))
-            end for k in dataarrays]...))),
-
-            # body
-            begin
-                # Advance iterators for DataArray and determine missing status
-                $(Expr(:block, [
-                    As[k] <: DataArray ? quote
-                        @inbounds $(Symbol("ismissing_$(k)")) = Base.unsafe_bitgetindex($(Symbol("na_$(k)")), $(Symbol("state_$(k)_0")))
-                    end : As[k] <: PooledDataArray ? quote
-                        @inbounds $(Symbol("r_$(k)")) = @nref $nd $(Symbol("refs_$(k)")) d->$(Symbol("j_$(k)_d"))
-                        $(Symbol("ismissing_$(k)")) = $(Symbol("r_$(k)")) == 0
-                    end : nothing
-                for k = 1:N]...))
-
-                # Extract values for other type
-                $(Expr(:block, [
-                    As[k] <: AbstractArray  && !(As[k] <: AbstractDataArray) ? quote
-                        # ordinary AbstractArrays
-                        @inbounds $(Symbol("v_$(k)")) = @nref $nd $(Symbol("A_$(k)")) d->$(Symbol("j_$(k)_d"))
-                    end : quote
-                        # non AbstractArrays (e.g. Strings and Numbers)
-                        @inbounds $(Symbol("v_$(k)")) = $(Symbol("A_$(k)"))
-                    end
-                for k = 1:N]...))
-
-                # Compute and store return value
-                $(gen_na_conds(F, nd, As, B))
-
-                # Increment state
-                $(Expr(:block, [:($(Symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
-                $(if B <: DataArray
-                    :(ind += 1)
-                end)
+            # Set up output DataArray/PooledDataArray
+            $(if B <: DataArray
+                quote
+                    Bdata = B.data
+                    # Copy in case aliased
+                    # TODO: check for aliasing?
+                    Bna = falses(size(Bdata))
+                    Bc = Bna.chunks
+                    ind = 1
+                end
+            elseif B <: PooledDataArray
+                quote
+                    Bpool = B.pool = similar(B.pool, 0)
+                    Brefs = B.refs
+                    Brefdict = Dict{eltype(Bpool),eltype(Brefs)}()
+                end
             end)
 
-        $(if B <: DataArray
-            :(B.na = Bna)
-        end)
+            @nloops($nd, i, $(B <: DataArray ? (:Bdata) : (:Brefs)),
+                # pre
+                d->($(Expr(:block, [
+                    As[k] <: DataArray ? quote
+                        $(Symbol("state_$(k)_")){d-1} = $(Symbol("state_$(k)_d"));
+                        $(Symbol("j_$(k)_d")) = $(Symbol("skip_$(k)_d")) ? 1 : i_d
+                    end : (As[k] <: AbstractArray ? quote
+                        $(Symbol("j_$(k)_d")) = size($(Symbol("A_$(k)")), d) == 1 ? 1 : i_d
+                    end : quote
+                        $(Symbol("j_$(k)_d")) = 1
+                    end)
+                for k = 1:N]...))),
 
-        return B
+                # post
+                d->($(Expr(:block, [quote
+                    $(Symbol("skip_$(k)_d")) || ($(Symbol("state_$(k)_d")) = $(Symbol("state_$(k)_0")))
+                end for k in dataarrays]...))),
+
+                # body
+                begin
+                    # Advance iterators for DataArray and determine missing status
+                    $(Expr(:block, [
+                        As[k] <: DataArray ? quote
+                            @inbounds $(Symbol("ismissing_$(k)")) = Base.unsafe_bitgetindex($(Symbol("na_$(k)")), $(Symbol("state_$(k)_0")))
+                        end : As[k] <: PooledDataArray ? quote
+                            @inbounds $(Symbol("r_$(k)")) = @nref $nd $(Symbol("refs_$(k)")) d->$(Symbol("j_$(k)_d"))
+                            $(Symbol("ismissing_$(k)")) = $(Symbol("r_$(k)")) == 0
+                        end : nothing
+                    for k = 1:N]...))
+
+                    # Extract values for other type
+                    $(Expr(:block, [
+                        As[k] <: AbstractArray  && !(As[k] <: AbstractDataArray) ? quote
+                            # ordinary AbstractArrays
+                            @inbounds $(Symbol("v_$(k)")) = @nref $nd $(Symbol("A_$(k)")) d->$(Symbol("j_$(k)_d"))
+                        end : quote
+                            # non AbstractArrays (e.g. Strings and Numbers)
+                            @inbounds $(Symbol("v_$(k)")) = $(Symbol("A_$(k)"))
+                        end
+                    for k = 1:N]...))
+
+                    # Compute and store return value
+                    $(gen_na_conds(F, nd, As, B))
+
+                    # Increment state
+                    $(Expr(:block, [:($(Symbol("state_$(k)_0")) += 1) for k in dataarrays]...))
+                    $(if B <: DataArray
+                        :(ind += 1)
+                    end)
+                end)
+
+            $(if B <: DataArray
+                :(B.na = Bna)
+            end)
+
+            return B
+        end
     end
+    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, ::Type{T}, As...) where T =
+        _broadcast!((t...) -> f(T, t...), B, As...)
+    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0::Number, As::Number...) =
+        _broadcast!(f, B, A0, As...)
+    Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0, As...) =
+        _broadcast!(f, B, A0, As...)
+
+    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{DataArray})             = DataArray
+    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{PooledDataArray}) = PooledDataArray
+    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{Array})                 = DataArray
+    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{Array})           = PooledDataArray
+    Base.Broadcast.promote_containertype(::Type{Array}, ::Type{DataArray})                 = DataArray
+    Base.Broadcast.promote_containertype(::Type{Array}, ::Type{PooledDataArray})           = PooledDataArray
+    Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{PooledDataArray})       = DataArray
+    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{DataArray})       = DataArray
+    Base.Broadcast.promote_containertype(::Type{DataArray}, ct)                            = DataArray
+    Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ct)                      = PooledDataArray
+    Base.Broadcast.promote_containertype(ct, ::Type{DataArray})                            = DataArray
+    Base.Broadcast.promote_containertype(ct, ::Type{PooledDataArray})                      = PooledDataArray
+    Base.Broadcast._containertype(::Type{T}) where T<:DataArray           = DataArray
+    Base.Broadcast._containertype(::Type{T}) where T<:PooledDataArray     = PooledDataArray
+    Base.Broadcast.broadcast_indices(::Type{T}, A) where T<:AbstractDataArray = indices(A)
+
+    @inline function broadcast_t(f, ::Type{T}, shape, A, Bs...) where {T}
+        dest = Base.Broadcast.containertype(A, Bs...)(Missings.T(T), Base.index_lengths(shape...))
+        return broadcast!(f, dest, A, Bs...)
+    end
+
+    # This is mainly to handle ismissing.(x) since ismissing is probably the only
+    # function that can guarantee that missings will never propagate
+    @inline function broadcast_t(f, ::Type{Bool}, shape, A, Bs...)
+        dest = similar(BitArray, shape)
+        return broadcast!(f, dest, A, Bs...)
+    end
+
+    # This one is almost identical to the version in Base and can hopefully be
+    # removed at some point. The main issue in Base is that it tests for
+    # isleaftype(T) which is false for Union{T,Missing}. If the test in Base
+    # can be modified to cover simple unions of leaftypes then this method
+    # can probably be deleted and the two _t methods adjusted to match the Base
+    # invokation from Base.Broadcast.broadcast_c
+    @inline function Base.Broadcast.broadcast_c(f, ::Type{S}, A, Bs...) where {S<:AbstractDataArray}
+        T     = Base.Broadcast._broadcast_eltype(f, A, Bs...)
+        shape = Base.Broadcast.broadcast_indices(A, Bs...)
+        return broadcast_t(f, T, shape, A, Bs...)
+    end
+
+    # This one is much faster than normal broadcasting but the method won't get called
+    # in fusing operations like (!).(ismissing.(x))
+    Base.broadcast(::typeof(ismissing), da::DataArray) = copy(da.na)
 end
-Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, ::Type{T}, As...) where T =
-    _broadcast!((t...) -> f(T, t...), B, As...)
-Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0::Number, As::Number...) =
-    _broadcast!(f, B, A0, As...)
-Base.Broadcast.broadcast!(f, B::Union{DataArray, PooledDataArray}, A0, As...) =
-    _broadcast!(f, B, A0, As...)
-
-Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{DataArray})             = DataArray
-Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{PooledDataArray}) = PooledDataArray
-Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{Array})                 = DataArray
-Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{Array})           = PooledDataArray
-Base.Broadcast.promote_containertype(::Type{Array}, ::Type{DataArray})                 = DataArray
-Base.Broadcast.promote_containertype(::Type{Array}, ::Type{PooledDataArray})           = PooledDataArray
-Base.Broadcast.promote_containertype(::Type{DataArray}, ::Type{PooledDataArray})       = DataArray
-Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ::Type{DataArray})       = DataArray
-Base.Broadcast.promote_containertype(::Type{DataArray}, ct)                            = DataArray
-Base.Broadcast.promote_containertype(::Type{PooledDataArray}, ct)                      = PooledDataArray
-Base.Broadcast.promote_containertype(ct, ::Type{DataArray})                            = DataArray
-Base.Broadcast.promote_containertype(ct, ::Type{PooledDataArray})                      = PooledDataArray
-Base.Broadcast._containertype(::Type{T}) where T<:DataArray           = DataArray
-Base.Broadcast._containertype(::Type{T}) where T<:PooledDataArray     = PooledDataArray
-Base.Broadcast.broadcast_indices(::Type{T}, A) where T<:AbstractDataArray = indices(A)
-
-@inline function broadcast_t(f, ::Type{T}, shape, A, Bs...) where {T}
-    dest = Base.Broadcast.containertype(A, Bs...)(Missings.T(T), Base.index_lengths(shape...))
-    return broadcast!(f, dest, A, Bs...)
-end
-
-# This is mainly to handle ismissing.(x) since ismissing is probably the only
-# function that can guarantee that missings will never propagate
-@inline function broadcast_t(f, ::Type{Bool}, shape, A, Bs...)
-    dest = similar(BitArray, shape)
-    return broadcast!(f, dest, A, Bs...)
-end
-
-# This one is almost identical to the version in Base and can hopefully be
-# removed at some point. The main issue in Base is that it tests for
-# isleaftype(T) which is false for Union{T,Missing}. If the test in Base
-# can be modified to cover simple unions of leaftypes then this method
-# can probably be deleted and the two _t methods adjusted to match the Base
-# invokation from Base.Broadcast.broadcast_c
-@inline function Base.Broadcast.broadcast_c{S<:AbstractDataArray}(f, ::Type{S}, A, Bs...)
-    T     = Base.Broadcast._broadcast_eltype(f, A, Bs...)
-    shape = Base.Broadcast.broadcast_indices(A, Bs...)
-    return broadcast_t(f, T, shape, A, Bs...)
-end
-
-# This one is much faster than normal broadcasting but the method won't get called
-# in fusing operations like (!).(ismissing.(x))
-Base.broadcast(::typeof(ismissing), da::DataArray) = copy(da.na)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -57,7 +57,6 @@ end
 #
 # TODO: Fall back on faster implementation for same-sized inputs when
 # it is safe to do so.
-
 Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0::AbstractArray, As::AbstractArray...) where {F} =
         broadcast!(f, B, A0, As...)
 Base.map!(f::F, B::Union{DataArray, PooledDataArray}, A0, As...) where {F} =

--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -73,7 +73,7 @@ DataArray{T}(d::Array{S, N}) where {T, S, N} = DataArray{T, N}(d) # -> DataArray
 
 function DataArray{T, N}(d::Array,
                          m::BitArray{N} = falses(size(d))) where {T, N}  # -> DataArray{T}
-    convert(DataArray{Missings.T(T), N}, DataArray(d, m))
+    DataArray(convert(Array{Missings.T(T), N}, d), m)
 end
 
 function DataArray(d::Array{T, N},
@@ -341,7 +341,7 @@ end
 
 function Base.convert(::Type{DataArray{S, N}},
                       a::AbstractArray{T, N}) where {S, T, N} # -> DataArray{S, N}
-    return DataArray{S, N}(convert(Array, a), falses(size(a)))
+    return DataArray(convert(Array{S, N}, a), falses(size(a)))
 end
 
 function Base.convert(::Type{DataArray{S, N}},

--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -24,7 +24,7 @@ function Base.pop!(dv::DataVector)
 end
 
 function Base.unshift!(dv::DataVector{T}, v::Missing) where T
-    ccall(:jl_array_grow_beg, Nothing, (Any, UInt), dv.data, 1)
+    ccall(:jl_array_grow_beg, Cvoid, (Any, UInt), dv.data, 1)
     unshift!(dv.na, true)
     return v
 end

--- a/src/datavector.jl
+++ b/src/datavector.jl
@@ -24,7 +24,7 @@ function Base.pop!(dv::DataVector)
 end
 
 function Base.unshift!(dv::DataVector{T}, v::Missing) where T
-    ccall(:jl_array_grow_beg, Void, (Any, UInt), dv.data, 1)
+    ccall(:jl_array_grow_beg, Nothing, (Any, UInt), dv.data, 1)
     unshift!(dv.na, true)
     return v
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -63,7 +63,7 @@ end
 import Base: &, |, xor
 
 for f in [:(&), :(|), :(xor)]
-    for T in [:(BitArray), :(Range{<:Integer}), :(AbstractArray{<:Integer}), :(Integer)]
+    for T in [:(BitArray), :(AbstractRange{<:Integer}), :(AbstractArray{<:Integer}), :(Integer)]
         @eval begin
             @deprecate ($f)(a::DataArray{<:Integer}, b::$T) ($f).(a, b)
             @deprecate ($f)(a::$T, b::DataArray{<:Integer}) ($f).(a, b)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -62,7 +62,7 @@ function combine_pools!(pool, newpool)
     end
 
     # Find pool elements in existing array, or add them
-    poolidx = Vector{Int}(length(newpool))
+    poolidx = Vector{Int}(uninitialized, length(newpool))
     for j = 1:length(newpool)
         poolidx[j] = Base.@get!(seen, newpool[j], (push!(pool, newpool[j]); i += 1))
     end
@@ -86,7 +86,7 @@ elseif isdefined(Base, :checkindex)
         throw(MissingException("missing values are not allowed in indices"))
 else
     Base.checkbounds(::Type{Bool}, sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz
-    function Base.checkbounds{T<:Real}(::Type{Bool}, sz::Int, I::AbstractDataArray{T})
+    function Base.checkbounds(::Type{Bool}, sz::Int, I::AbstractDataArray{T}) where {T<:Real}
         any(ismissing, I) && throw(MissingException("missing values are not allowed in indices"))
         extr = daextract(I)
         b = true

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -6,8 +6,8 @@
 
 # Impute a missing entries using current approximation.
 function impute!(X::Matrix, missing_entries::Vector,
-                 U::Matrix, D::Vector, V::Matrix,
-                 k::Integer)
+                 U::Matrix, D::Vector, V::AbstractArray{T, 2},
+                 k::Integer) where T
     approximation = U[:, 1:k] * diagm(D[1:k]) * V[1:k, :]
     for indices in missing_entries
         X[indices[1], indices[2]] = approximation[indices[1], indices[2]]

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -6,8 +6,8 @@
 
 # Impute a missing entries using current approximation.
 function impute!(X::Matrix, missing_entries::Vector,
-                 U::Matrix, D::Vector, V::AbstractArray{T, 2},
-                 k::Integer) where T
+                 U::Matrix, D::Vector, V::AbstractMatrix,
+                 k::Integer)
     approximation = U[:, 1:k] * diagm(D[1:k]) * V[1:k, :]
     for indices in missing_entries
         X[indices[1], indices[2]] = approximation[indices[1], indices[2]]

--- a/src/literals.jl
+++ b/src/literals.jl
@@ -1,7 +1,7 @@
 function fixargs(args::Vector{Any}, stub::Any)
     n = length(args)
-    data = Array{Any}(n)
-    na = BitArray(n)
+    data = Array{Any}(uninitialized, n)
+    na = BitArray(uninitialized, n)
     for i in 1:n
         if args[i] == :missing || args[i] == :NA
             data[i] = stub
@@ -73,8 +73,8 @@ function parsematrix(ex::Expr)
     end
 
     nrows = length(rows)
-    datarows = Array{Expr}(nrows)
-    narows   = Array{Expr}(nrows)
+    datarows = Array{Expr}(uninitialized, nrows)
+    narows   = Array{Expr}(uninitialized, nrows)
     for irow in 1:nrows
         data, na = fixargs(ex.args[rows[irow]].args, stub)
         datarows[irow] = Expr(:row, data...)

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -541,8 +541,8 @@ function Base.permute!!(x::PooledDataArray, p::AbstractVector{T}) where T<:Integ
     x
 end
 
-function Base.ipermute!!(x::PooledDataArray, p::AbstractVector{T}) where T<:Integer
-    Base.ipermute!!(x.refs, p)
+function invpermute!!(x::PooledDataArray, p::AbstractVector{T}) where T<:Integer
+    invpermute!!(x.refs, p)
     x
 end
 
@@ -811,22 +811,22 @@ function PooledDataVecs(v1::AbstractArray,
 end
 
 Base.convert(::Type{PooledDataArray{S,R1,N}},
-                      pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
+             pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
     PooledDataArray(RefArray(convert(Array{R1,N}, pda.refs)), convert(Vector{S}, pda.pool))
 
 Base.convert(::Type{PooledDataArray{S,R,N}},
-                      pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
+             pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
     PooledDataArray(RefArray(copy(pda.refs)), convert(Vector{S}, pda.pool))
 
 Base.convert(::Type{PooledDataArray{T,R,N}},
              pda::PooledDataArray{T,R,N}) where {T,R<:Integer,N} = pda
 
 Base.convert(::Type{PooledDataArray{S,R1}},
-                      pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
+             pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
     convert(PooledDataArray{S,R1,N}, pda)
 
 Base.convert(::Type{PooledDataArray{S}},
-                      pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
+             pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
     convert(PooledDataArray{S,R,N}, pda)
 
 Base.convert(::Type{PooledDataArray}, pda::PooledDataArray{T,R,N}) where {T,R<:Integer,N} = pda

--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -117,7 +117,7 @@ function PooledDataArray(d::AbstractArray{<:Union{T,Missing}, N},
         throw(ArgumentError("Cannot construct a PooledDataVector with type $R with a pool of size $(length(pool))"))
     end
 
-    newrefs = Array{R,N}(size(d))
+    newrefs = Array{R,N}(uninitialized, size(d))
     poolref = Dict{T, R}()
 
     # loop through once to fill the poolref dict
@@ -149,7 +149,7 @@ end
 
 # Construct an all-missing PooledDataVector of a specific type
 PooledDataArray(t::Type, dims::Tuple{Vararg{Int}}) = PooledDataArray(Array{t}(dims), trues(dims))
-PooledDataArray(t::Type, dims::Int...) = PooledDataArray(Array{t}(dims), trues(dims))
+PooledDataArray(t::Type, dims::Int...) = PooledDataArray(Array{t}(uninitialized, dims), trues(dims))
 PooledDataArray(t::Type, r::Type{R}, dims::Tuple{Vararg{Int}}) where {R<:Integer} = PooledDataArray(Array{t}(dims), trues(dims), r)
 PooledDataArray(t::Type, r::Type{R}, dims::Int...) where {R<:Integer} = PooledDataArray(Array(t, dims), trues(dims), r)
 
@@ -178,7 +178,7 @@ PooledDataArray(d::Array{T},
                 r::Type{R} = DEFAULT_POOLED_REF_TYPE) where {T,R<:Integer} = PooledDataArray(d, pool, falses(size(d)), r)
 
 # Explicitly convert Ranges into a PooledDataVector
-PooledDataArray(rs::Range,
+PooledDataArray(rs::AbstractRange,
                 r::Type{R} = DEFAULT_POOLED_REF_TYPE) where {R<:Integer} = PooledDataArray(collect(rs), falses(length(rs)), r)
 
 # Initialized constructors with 0's, 1's
@@ -186,7 +186,7 @@ for (f, basef) in ((:pdatazeros, :zeros), (:pdataones, :ones))
     @eval begin
         ($f)(dims::Int...) = PooledDataArray(($basef)(dims...), falses(dims...))
         ($f)(t::Type, dims::Int...) = PooledDataArray(($basef)(t, dims...), falses(dims...))
-        ($f){R<:Integer}(t::Type, r::Type{R}, dims::Int...) = PooledDataArray(($basef)(t, dims...), falses(dims...), r)
+        ($f)(t::Type, r::Type{R}, dims::Int...) where {R<:Integer} = PooledDataArray(($basef)(t, dims...), falses(dims...), r)
     end
 end
 
@@ -810,40 +810,56 @@ function PooledDataVecs(v1::AbstractArray,
             PooledDataArray(RefArray(refs2), pool))
 end
 
-Base.convert{S,T,R1<:Integer,R2<:Integer,N}(::Type{PooledDataArray{S,R1,N}}, pda::PooledDataArray{T,R2,N}) =
+Base.convert(::Type{PooledDataArray{S,R1,N}},
+                      pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
     PooledDataArray(RefArray(convert(Array{R1,N}, pda.refs)), convert(Vector{S}, pda.pool))
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S,R,N}}, pda::PooledDataArray{T,R,N}) =
+
+Base.convert(::Type{PooledDataArray{S,R,N}},
+                      pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
     PooledDataArray(RefArray(copy(pda.refs)), convert(Vector{S}, pda.pool))
-Base.convert{T,R<:Integer,N}(::Type{PooledDataArray{T,R,N}}, pda::PooledDataArray{T,R,N}) = pda
-Base.convert{S,T,R1<:Integer,R2<:Integer,N}(::Type{PooledDataArray{S,R1}}, pda::PooledDataArray{T,R2,N}) =
+
+Base.convert(::Type{PooledDataArray{T,R,N}},
+             pda::PooledDataArray{T,R,N}) where {T,R<:Integer,N} = pda
+
+Base.convert(::Type{PooledDataArray{S,R1}},
+                      pda::PooledDataArray{T,R2,N}) where {S,T,R1<:Integer,R2<:Integer,N} =
     convert(PooledDataArray{S,R1,N}, pda)
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S}}, pda::PooledDataArray{T,R,N}) =
+
+Base.convert(::Type{PooledDataArray{S}},
+                      pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
     convert(PooledDataArray{S,R,N}, pda)
-Base.convert{T,R<:Integer,N}(::Type{PooledDataArray}, pda::PooledDataArray{T,R,N}) = pda
 
-Base.convert{T,R<:Integer,N}(::Type{PooledDataArray{T,R,N}}, a::DataArray{T,N}) =
+Base.convert(::Type{PooledDataArray}, pda::PooledDataArray{T,R,N}) where {T,R<:Integer,N} = pda
+
+Base.convert(::Type{PooledDataArray{T,R,N}}, a::DataArray{T,N}) where {T,R<:Integer,N} =
     PooledDataArray(a.data, a.na, R)
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S,R,N}}, a::DataArray{T,N}) =
-    convert(PooledDataArray{S,R,N}, PooledDataArray(a.data, a.na, R))
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S,R}}, a::DataArray{T,N}) =
-    convert(PooledDataArray{S,R,N}, PooledDataArray(a.data, a.na, R))
-Base.convert{S,T,N}(::Type{PooledDataArray{S}}, a::DataArray{T,N}) =
-    convert(PooledDataArray{S}, PooledDataArray(a.data, a.na))
-Base.convert(::Type{PooledDataArray}, a::DataArray) =
-    PooledDataArray(a.data, a.na)
 
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S,R,N}}, a::AbstractArray{T,N}) =
+Base.convert(::Type{PooledDataArray{S,R,N}}, a::DataArray{T,N}) where {S,T,R<:Integer,N} =
+    convert(PooledDataArray{S,R,N}, PooledDataArray(a.data, a.na, R))
+
+Base.convert(::Type{PooledDataArray{S,R}}, a::DataArray{T,N}) where {S,T,R<:Integer,N} =
+    convert(PooledDataArray{S,R,N}, PooledDataArray(a.data, a.na, R))
+
+Base.convert(::Type{PooledDataArray{S}}, a::DataArray{T,N}) where {S,T,N} =
+    convert(PooledDataArray{S}, PooledDataArray(a.data, a.na))
+
+Base.convert(::Type{PooledDataArray}, a::DataArray) = PooledDataArray(a.data, a.na)
+
+Base.convert(::Type{PooledDataArray{S,R,N}}, a::AbstractArray{T,N}) where {S,T,R<:Integer,N} =
     PooledDataArray(convert(Array{S,N}, a), falses(size(a)), R)
-Base.convert{S,T,R<:Integer,N}(::Type{PooledDataArray{S,R}}, a::AbstractArray{T,N}) =
+
+Base.convert(::Type{PooledDataArray{S,R}},a::AbstractArray{T,N}) where {S,T,R<:Integer,N} =
     PooledDataArray(convert(Array{S,N}, a), falses(size(a)), R)
-Base.convert{S,T,N}(::Type{PooledDataArray{S}}, a::AbstractArray{T,N}) =
+
+Base.convert(::Type{PooledDataArray{S}}, a::AbstractArray{T,N}) where {S,T,N} =
     PooledDataArray(convert(Array{S,N}, a), falses(size(a)))
+
 Base.convert(::Type{PooledDataArray}, a::AbstractArray) =
     PooledDataArray(a, falses(size(a)))
 
-function Base.convert{S,T,R<:Integer,N}(::Type{DataArray{S,N}},
-                                        pda::PooledDataArray{T,R,N})
-    res = DataArray(Array{S}(size(pda)), BitArray(size(pda)))
+function Base.convert(::Type{DataArray{S,N}},
+                      pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N}
+    res = DataArray(Array{S}(uninitialized, size(pda)), BitArray(uninitialized, size(pda)))
     for i in 1:length(pda)
         r = pda.refs[i]
         if r == 0 # TODO: Use zero(R)
@@ -855,17 +871,16 @@ function Base.convert{S,T,R<:Integer,N}(::Type{DataArray{S,N}},
     end
     return res
 end
-Base.convert{S,T,R<:Integer,N}(::Type{DataArray{S}}, pda::PooledDataArray{T,R,N}) =
+
+Base.convert(::Type{DataArray{S}}, pda::PooledDataArray{T,R,N}) where {S,T,R<:Integer,N} =
     convert(DataArray{S,N}, pda)
-Base.convert{T,R<:Integer,N}(::Type{DataArray}, pda::PooledDataArray{T,R,N}) =
+
+Base.convert(::Type{DataArray}, pda::PooledDataArray{T,R,N}) where {T,R<:Integer,N} =
     convert(DataArray{T,N}, pda)
 
 pdata(a::AbstractArray) = convert(PooledDataArray, a)
 
-function Base.convert{S, T, R, N}(
-    ::Type{Array{S, N}},
-    pda::PooledDataArray{T, R, N})
-
+function Base.convert(::Type{Array{S, N}}, pda::PooledDataArray{T, R, N}) where {S, T, R, N}
     res = Array{S}(size(pda))
     for i in 1:length(pda)
         if pda.refs[i] == zero(R)
@@ -877,24 +892,24 @@ function Base.convert{S, T, R, N}(
     return res
 end
 
-function Base.convert{T, R}(::Type{Vector}, pdv::PooledDataVector{T, R})
+function Base.convert(::Type{Vector}, pdv::PooledDataVector{T, R}) where {T, R}
     return convert(Array{T, 1}, pdv)
 end
 
-function Base.convert{T, R}(::Type{Matrix}, pdm::PooledDataMatrix{T, R})
+function Base.convert(::Type{Matrix}, pdm::PooledDataMatrix{T, R}) where {T, R}
     return convert(Array{T, 2}, pdm)
 end
 
-function Base.convert{T, R, N}(::Type{Array}, pda::PooledDataArray{T, R, N})
+function Base.convert(::Type{Array}, pda::PooledDataArray{T, R, N}) where {T, R, N}
     return convert(Array{T, N}, pda)
 end
 
-function Base.convert{S, T, R, N}(
+function Base.convert(
     ::Type{Array{S, N}},
     pda::PooledDataArray{T, R, N},
-    replacement::Any)
+    replacement::Any) where {S, T, R, N}
 
-    res = Array{S}(size(pda))
+    res = Array{S}(uninitialized, size(pda))
     replacementS = convert(S, replacement)
     for i in 1:length(pda)
         if pda.refs[i] == zero(R)
@@ -906,15 +921,15 @@ function Base.convert{S, T, R, N}(
     return res
 end
 
-function Base.convert{T, R}(::Type{Vector}, pdv::PooledDataVector{T, R}, replacement::Any)
+function Base.convert(::Type{Vector}, pdv::PooledDataVector{T, R}, replacement::Any) where {T, R}
     return convert(Array{T, 1}, pdv, replacement)
 end
 
-function Base.convert{T, R}(::Type{Matrix}, pdm::PooledDataMatrix{T, R}, replacement::Any)
+function Base.convert(::Type{Matrix}, pdm::PooledDataMatrix{T, R}, replacement::Any) where {T, R}
     return convert(Array{T, 2}, pdm, replacement)
 end
 
-function Base.convert{T, R, N}(::Type{Array}, pda::PooledDataArray{T, R, N}, replacement::Any)
+function Base.convert(::Type{Array}, pda::PooledDataArray{T, R, N}, replacement::Any) where {T, R, N}
     return convert(Array{T, N}, pda, replacement)
 end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -100,7 +100,9 @@
     #@test all([length(x)::Int for x in dvstr] == [3, 3, 1, 4])
     # Julia 0.6 and 0.7 differ in ordering of Unions
     @test repr(dvint) in ("Union{$Int, Missings.Missing}[1, 2, missing, 4]",
-                          "Union{Missings.Missing, $Int}[1, 2, missing, 4]")
+                          "Union{Missings.Missing, $Int}[1, 2, missing, 4]",
+                          "Union{$Int, Missing}[1, 2, missing, 4]",
+                          "Union{Missing, $Int}[1, 2, missing, 4]")
 
     #test_group("PooledDataVector to something else")
     @test collect(skipmissing(pdvstr)) == ["one", "one", "two", "two", "one", "one"]
@@ -174,9 +176,9 @@
 
     #test_group("PooledDataVector replace!")
     pdvstr2 = @pdata ["one", "one", "two", "two", "three"]
-    @test replace!(pdvstr2, "two", "four") == "four"
-    @test replace!(pdvstr2, "three", "four") == "four"
-    @test ismissing.(replace!(pdvstr2, "one", missing))
-    @test replace!(pdvstr2, missing, "five") == "five"
+    @test DataArrays.replace!(pdvstr2, "two", "four") == "four"
+    @test DataArrays.replace!(pdvstr2, "three", "four") == "four"
+    @test ismissing.(DataArrays.replace!(pdvstr2, "one", missing))
+    @test DataArrays.replace!(pdvstr2, missing, "five") == "five"
     @test isequal(pdvstr2, (@data ["five", "five", "four", "four", "four"]))
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -176,9 +176,9 @@
 
     #test_group("PooledDataVector replace!")
     pdvstr2 = @pdata ["one", "one", "two", "two", "three"]
-    @test DataArrays.replace!(pdvstr2, "two", "four") == "four"
-    @test DataArrays.replace!(pdvstr2, "three", "four") == "four"
-    @test ismissing.(DataArrays.replace!(pdvstr2, "one", missing))
-    @test DataArrays.replace!(pdvstr2, missing, "five") == "five"
+    @test replace!(pdvstr2, "two", "four") == "four"
+    @test replace!(pdvstr2, "three", "four") == "four"
+    @test ismissing.(replace!(pdvstr2, "one", missing))
+    @test replace!(pdvstr2, missing, "five") == "five"
     @test isequal(pdvstr2, (@data ["five", "five", "four", "four", "four"]))
 end

--- a/test/dataarray.jl
+++ b/test/dataarray.jl
@@ -5,7 +5,7 @@
     m = [1 2; 3 4]
     dm = DataArray(m, falses(size(m)))
 
-    t = Array{Int}(2, 2, 2)
+    t = Array{Int}(uninitialized, 2, 2, 2)
     t[1:2, 1:2, 1:2] = 1
     dt = DataArray(t, falses(size(t)))
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -113,7 +113,7 @@ end
         for da in (da, convert(DataArray{Number}, da))
             let da = copy(da), dat = copy(dat)
                 # No missing
-                @test isequal(da.', dat)
+                @test isequal(transpose(da), dat)
                 @test isequal(da', conj(dat))
 
                 # With missing
@@ -125,7 +125,7 @@ end
 
                 # Make sure that missings are undefined in the non-bits array
                 da = conj(conj(da))
-                @test isequal(da.', dat)
+                @test isequal(transpose(da), dat)
                 @test isequal(da', conj(dat))
             end
         end
@@ -204,7 +204,7 @@ end
     # Binary operations on pairs of DataVector's
     dv = convert(DataArray, ones(5))
     # Dates are an example of type for which - and .- return a different type from its inputs
-    dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
+    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
     dv[1] = dvd[1] = missing
     @test_da_pda dv begin
         for f in [+, -, *, ^]
@@ -269,13 +269,13 @@ end
 
     dv = @data([911, 269, 835.0, 448, 772])
     # Dates are an example of type for which operations return a different type from their inputs
-    dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
+    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
     for f in pairwise_vector_operators
         @test isequal(f(dv), f(dv.data))
         @test isequal(f(dvd), f(dvd.data))
     end
     dv = @data([missing, 269, 835.0, 448, 772])
-    dvd = @data([missing, Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05")])
+    dvd = @data([missing, Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[1])
@@ -286,7 +286,7 @@ end
         @test isequal(d[2:3], f(dvd.data)[2:3])
     end
     dv = @data([911, missing, 835.0, 448, 772])
-    dvd = @data([Base.Date("2000-01-01"), missing, Base.Date("2010-01-01"), Base.Date("2010-01-05")])
+    dvd = @data([Dates.Date("2000-01-01"), missing, Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[1])
@@ -299,7 +299,7 @@ end
         @test isequal(d[3:3], f(dvd.data)[3:3])
     end
     dv = @data([911, 269, 835.0, 448, missing])
-    dvd = @data([Base.Date("2000-01-01"), Base.Date("2010-01-01"), Base.Date("2010-01-05"), missing])
+    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05"), missing])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[4])

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -204,7 +204,7 @@ end
     # Binary operations on pairs of DataVector's
     dv = convert(DataArray, ones(5))
     # Dates are an example of type for which - and .- return a different type from its inputs
-    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
+    dvd = @data([Date("2000-01-01"), Date("2010-01-01"), Date("2010-01-05")])
     dv[1] = dvd[1] = missing
     @test_da_pda dv begin
         for f in [+, -, *, ^]
@@ -269,13 +269,13 @@ end
 
     dv = @data([911, 269, 835.0, 448, 772])
     # Dates are an example of type for which operations return a different type from their inputs
-    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
+    dvd = @data([Date("2000-01-01"), Date("2010-01-01"), Date("2010-01-05")])
     for f in pairwise_vector_operators
         @test isequal(f(dv), f(dv.data))
         @test isequal(f(dvd), f(dvd.data))
     end
     dv = @data([missing, 269, 835.0, 448, 772])
-    dvd = @data([missing, Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
+    dvd = @data([missing, Date("2000-01-01"), Date("2010-01-01"), Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[1])
@@ -286,7 +286,7 @@ end
         @test isequal(d[2:3], f(dvd.data)[2:3])
     end
     dv = @data([911, missing, 835.0, 448, 772])
-    dvd = @data([Dates.Date("2000-01-01"), missing, Dates.Date("2010-01-01"), Dates.Date("2010-01-05")])
+    dvd = @data([Date("2000-01-01"), missing, Date("2010-01-01"), Date("2010-01-05")])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[1])
@@ -299,7 +299,7 @@ end
         @test isequal(d[3:3], f(dvd.data)[3:3])
     end
     dv = @data([911, 269, 835.0, 448, missing])
-    dvd = @data([Dates.Date("2000-01-01"), Dates.Date("2010-01-01"), Dates.Date("2010-01-05"), missing])
+    dvd = @data([Date("2000-01-01"), Date("2010-01-01"), Date("2010-01-05"), missing])
     for f in pairwise_vector_operators
         v = f(dv)
         @test ismissing(v[4])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@
 # Correctness Tests
 #
 
-using Base.Test
+using Compat: uninitialized
+using Compat.Test, Compat.Dates, Compat.Printf
 using DataArrays
 
 my_tests = ["abstractarray.jl",


### PR DESCRIPTION
Fixes various deprecation warnings and some errors that prevent DataArrays from precompiling on 0.7 while maintaining compatibility with 0.6.

This is a WIP because I'm waiting for a new Compat version to be released to fix the `ipermute!` -> `invpermute!` error.