### PR TITLE
Remove sumabs, sumabs2, maxabs and minabs

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -146,12 +146,6 @@ for (fn, op) in ((:(Base.sum), +),
     end
 end
 
-for (fn, f, op) in ((:(Base.sumabs), abs, +),
-                    (:(Base.sumabs2), abs2, +))
-    @eval $fn(a::DataArray; skipmissing::Bool=false, skipna::Bool=false) =
-        mapreduce($f, $op, a; skipmissing=skipmissing, skipna=skipna)
-end
-
 ## mean
 
 Base.mean(a::DataArray; skipmissing::Bool=false, skipna::Bool=false) =

--- a/src/reducedim.jl
+++ b/src/reducedim.jl
@@ -303,22 +303,6 @@ for (basfn, Op) in [(:sum, +), (:prod, *),
     end
 end
 
-for (basfn, fbase, Fun) in [(:sumabs, :sum, abs),
-                            (:sumabs2, :sum, abs2),
-                            (:maxabs, :maximum, abs),
-                            (:minabs, :minimum, abs)]
-    fname = Expr(:., :Base, Base.Meta.quot(basfn))
-    fname! = Expr(:., :Base, Base.Meta.quot(Symbol(string(basfn, '!'))))
-    fbase! = Expr(:., :Base, Base.Meta.quot(Symbol(string(fbase, '!'))))
-    @eval begin
-        $(fname!)(r::AbstractArray, A::DataArray;
-                  init::Bool=true, skipmissing::Bool=false, skipna::Bool=false) =
-            $(fbase!)($(Fun), r, A; init=init, skipmissing=skipmissing, skipna=skipna)
-        $(fname)(A::DataArray, region; skipmissing::Bool=false, skipna::Bool=false) =
-            $(fbase)($(Fun), A, region; skipmissing=skipmissing, skipna=skipna)
-    end
-end
-
 ## mean
 
 function Base.mean!(R::AbstractArray{T}, A::DataArray;

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -87,7 +87,7 @@ end
 
     for fn in (prod, minimum, maximum, mean,
                var, _varuc, _varzm, _varzmuc, _var1m, _var1muc,
-               std, _std1m, Base.sumabs, Base.sumabs2)
+               std, _std1m)
         for n in [0, 1, 2, 62, 63, 64, 65, 66]
             da = DataArray(randn(n))
             @same_behavior fn(da) fn(da.data)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -142,8 +142,6 @@ end
                         @test_da_approx_eq maximum!(r, Areduc; skipmissing=skipmissing) safe_mapslices(maximum, Areduc, region, skipmissing)
                         @test_da_approx_eq minimum!(r, Areduc; skipmissing=skipmissing) safe_mapslices(minimum, Areduc, region, skipmissing)
                     end
-                    @test_da_approx_eq Base.sumabs!(r, Areduc; skipmissing=skipmissing) safe_mapslices(sum, abs(Areduc), region, skipmissing)
-                    @test_da_approx_eq Base.sumabs2!(r, Areduc; skipmissing=skipmissing) safe_mapslices(sum, abs2(Areduc), region, skipmissing)
                     @test_da_approx_eq mean!(r, Areduc; skipmissing=skipmissing) safe_mapslices(mean, Areduc, region, skipmissing)
                 end
 
@@ -151,8 +149,6 @@ end
                 @test_da_approx_eq prod(Areduc, region; skipmissing=skipmissing) safe_mapslices(prod, Areduc, region, skipmissing)
                 @test_da_approx_eq maximum(Areduc, region; skipmissing=skipmissing) safe_mapslices(maximum, Areduc, region, skipmissing)
                 @test_da_approx_eq minimum(Areduc, region; skipmissing=skipmissing) safe_mapslices(minimum, Areduc, region, skipmissing)
-                @test_da_approx_eq Base.sumabs(Areduc, region; skipmissing=skipmissing) safe_mapslices(sum, abs(Areduc), region, skipmissing)
-                @test_da_approx_eq Base.sumabs2(Areduc, region; skipmissing=skipmissing) safe_mapslices(sum, abs2(Areduc), region, skipmissing)
                 @test_da_approx_eq mean(Areduc, region; skipmissing=skipmissing) safe_mapslices(mean, Areduc, region, skipmissing)
 
                 if region != 5


### PR DESCRIPTION
These have been deprecated in Julia 0.6, and removed in 0.7. The deprecation uses sum, minimum and maximum, so no replacement is needed.

This allows loading the package on recent Julia 0.7.